### PR TITLE
Remove tar_tmp_path from g6test.yml

### DIFF
--- a/.github/workflows/g6test.yml
+++ b/.github/workflows/g6test.yml
@@ -34,7 +34,6 @@ jobs:
           port: ${{ vars.PORT }}
           source: "api.zip"
           target: "public_html"
-          tar_tmp_path: "/home/rc-crmapi"
 
       - name: Execute remote SSH commands
         uses: appleboy/ssh-action@v1.0.3


### PR DESCRIPTION
Removed tar_tmp_path from deployment configuration.