### PR TITLE
Improve Message Log Handling for Monday Integration

### DIFF
--- a/src/adapters/monday/index.js
+++ b/src/adapters/monday/index.js
@@ -1022,8 +1022,6 @@ async function upsertCallDisposition({ existingCallLog }) {
   return { logId: existingCallLog.thirdPartyLogId }
 }
 
-const MAX_THREAD_MESSAGES = 10
-
 async function createMessageLog({
   user,
   contactInfo,
@@ -1033,8 +1031,7 @@ async function createMessageLog({
   accessToken
 }) {
 
-  const resolvedAccessToken =
-    accessToken || user?.accessToken
+  const resolvedAccessToken = accessToken || user?.accessToken
 
   const company = await getCompanyByHostname({
     hostname: user.dataValues.hostname
@@ -1152,6 +1149,7 @@ async function createMessageLog({
 
 
 
+
 async function updateMessageLog({
   user,
   contactInfo,
@@ -1162,8 +1160,8 @@ async function updateMessageLog({
   accessToken
 }) {
 
-  const resolvedAccessToken =
-    accessToken || user?.accessToken
+  const MAX_THREAD_MESSAGES = 10
+  const resolvedAccessToken = accessToken || user?.accessToken
 
   const company = await getCompanyByHostname({
     hostname: user.dataValues.hostname
@@ -1171,7 +1169,6 @@ async function updateMessageLog({
 
   const boardId = company.tenantId
   const itemId = Number(contactInfo.id)
-
   const updateId = existingMessageLog.thirdPartyLogId
 
   const callLogsColumnId = await getOrCreateCallLogsColumn({
@@ -1193,7 +1190,7 @@ async function updateMessageLog({
     { updateId: [updateId] }
   )
 
-  let previousBody =
+  const previousBody =
     existing?.data?.updates?.[0]?.body || ''
 
   const sender =
@@ -1214,24 +1211,32 @@ async function updateMessageLog({
     newLine += `Fax Document:\n${faxDocLink}\n`
   }
 
-  let updatedBody = previousBody + newLine
-
-  const messageCount =
-    updatedBody.split('\n')
+  const messageLines =
+    previousBody
+      .split('\n')
       .filter(l => l.includes(':'))
-      .length
 
-  let updateResponse
+  const messageCount = messageLines.length
 
-  if (messageCount > MAX_THREAD_MESSAGES) {
+  let updatedBody
+  let response
+  let newThreadId = updateId
 
-    let newThread =
-      `SMS conversation with ${contactInfo.name}\n`
+  if (messageCount >= MAX_THREAD_MESSAGES) {
 
-    newThread +=
+    updatedBody =
+      `SMS conversation with ${contactInfo.name}\n` +
       `[${moment().format('YYYY-MM-DD HH:mm:ss')}] ${sender}: ${text}\n`
 
-    updateResponse = await mondayRequest(
+    if (recordingLink) {
+      updatedBody += `Recording:\n${recordingLink}\n`
+    }
+
+    if (faxDocLink) {
+      updatedBody += `Fax Document:\n${faxDocLink}\n`
+    }
+
+    response = await mondayRequest(
       resolvedAccessToken,
       `
       mutation ($itemId: ID!, $body: String!) {
@@ -1242,15 +1247,17 @@ async function updateMessageLog({
       `,
       {
         itemId,
-        body: newThread
+        body: updatedBody
       }
     )
 
-    updatedBody = newThread
+    newThreadId = response.data.create_update.id
 
   } else {
 
-    updateResponse = await mondayRequest(
+    updatedBody = previousBody + newLine
+
+    response = await mondayRequest(
       resolvedAccessToken,
       `
       mutation ($updateId: ID!, $body: String!) {
@@ -1317,9 +1324,7 @@ async function updateMessageLog({
   }
 
   return {
-    logId:
-      updateResponse?.data?.edit_update?.id ||
-      updateResponse?.data?.create_update?.id,
+    logId: newThreadId,
     returnMessage: {
       message: 'Message appended',
       messageType: 'success',

--- a/src/adapters/monday/index.js
+++ b/src/adapters/monday/index.js
@@ -567,10 +567,77 @@ async function findContact({ phoneNumber, accessToken, authHeader, user }) {
   }
 }
 
-async function findContactWithName() {
+async function findContactWithName({ name, accessToken, authHeader, user }) {
+
+  const company = await getCompanyByHostname({
+    hostname: user.dataValues.hostname
+  })
+
+  const boardId = company.tenantId
+
+  const resolvedAccessToken =
+    authHeader?.replace('Bearer ', '') || accessToken || user?.accessToken
+
+  const matchedContactInfo = []
+
+  if (!name) {
+    return {
+      successful: true,
+      matchedContactInfo: []
+    }
+  }
+
+  const res = await mondayRequest(
+    resolvedAccessToken,
+    `
+    query ($boardId: [ID!]) {
+      boards(ids: $boardId) {
+        items_page(limit: 50) {
+          items {
+            id
+            name
+          }
+        }
+      }
+    }
+    `,
+    { boardId: Number(boardId) }
+  )
+
+  const items =
+    res?.data?.boards?.[0]?.items_page?.items || []
+
+  if (res?.errors?.length) {
+    return {
+      successful: false,
+      returnMessage: {
+        messageType: 'error',
+        message: res?.errors?.[0]?.message || 'Failed to fetch contacts from Monday.',
+        ttl: 3000
+      }
+    }
+  }
+
+  const searchName = name.toLowerCase()
+
+  for (const item of items) {
+    if (item.name?.toLowerCase().includes(searchName)) {
+      matchedContactInfo.push({
+        id: item.id,
+        name: item.name
+      })
+    }
+  }
+
+  matchedContactInfo.push({
+    id: 'createNewContact',
+    name: 'Create new contact...',
+    isNewContact: true
+  })
+
   return {
     successful: true,
-    matchedContactInfo: []
+    matchedContactInfo
   }
 }
 
@@ -955,6 +1022,8 @@ async function upsertCallDisposition({ existingCallLog }) {
   return { logId: existingCallLog.thirdPartyLogId }
 }
 
+const MAX_THREAD_MESSAGES = 10
+
 async function createMessageLog({
   user,
   contactInfo,
@@ -963,7 +1032,9 @@ async function createMessageLog({
   faxDocLink,
   accessToken
 }) {
-  const resolvedAccessToken = accessToken || user?.accessToken
+
+  const resolvedAccessToken =
+    accessToken || user?.accessToken
 
   const company = await getCompanyByHostname({
     hostname: user.dataValues.hostname
@@ -972,38 +1043,30 @@ async function createMessageLog({
   const boardId = company.tenantId
   const itemId = Number(contactInfo.id)
 
-  // ------------------------
-  // Message type detection
-  // ------------------------
-  const messageType = recordingLink
-    ? 'Voicemail'
-    : faxDocLink
-      ? 'Fax'
-      : 'SMS'
+  const callLogsColumnId = await getOrCreateCallLogsColumn({
+    accessToken: resolvedAccessToken,
+    boardId,
+    columnName: 'Call Logs'
+  })
 
-  let subject = ''
-  let body = ''
+  const sender =
+    message.direction === 'Inbound'
+      ? contactInfo.name
+      : 'You'
 
-  switch (messageType) {
-    case 'SMS':
-      subject = `SMS conversation with ${contactInfo.name}`
-      body =
-        `SMS ${message.direction === 'Inbound' ? 'from' : 'to'} ${contactInfo.name}\n` +
-        `Message: ${message.subject || message.text || ''}`
-      break
+  const text = message.subject || message.text || ''
 
-    case 'Voicemail':
-      subject = `Voicemail from ${contactInfo.name}`
-      body = `Voicemail received`
-      break
+  let body = `SMS conversation with ${contactInfo.name}\n`
 
-    case 'Fax':
-      subject = `Fax from ${contactInfo.name}`
-      body = `Fax document received`
-      break
+  body += `[${moment().format('YYYY-MM-DD HH:mm:ss')}] ${sender}: ${text}\n`
+
+  if (recordingLink) {
+    body += `Recording:\n${recordingLink}\n`
   }
 
-  const fullBody = `${subject}\n${body}`
+  if (faxDocLink) {
+    body += `Fax Document:\n${faxDocLink}\n`
+  }
 
   const res = await mondayRequest(
     resolvedAccessToken,
@@ -1016,20 +1079,46 @@ async function createMessageLog({
     `,
     {
       itemId,
-      body: fullBody
+      body
     }
   )
 
   if (!res?.data?.create_update?.id) {
-    throw new Error('Failed to create message log in Monday')
+    throw new Error('Failed to create message log')
   }
 
   const updateId = res.data.create_update.id
 
+  if (callLogsColumnId) {
+    await mondayRequest(
+      resolvedAccessToken,
+      `
+      mutation ($boardId: ID!, $itemId: ID!, $columnId: String!, $value: String!) {
+        change_simple_column_value(
+          board_id: $boardId,
+          item_id: $itemId,
+          column_id: $columnId,
+          value: $value
+        ) {
+          id
+        }
+      }
+      `,
+      {
+        boardId,
+        itemId,
+        columnId: callLogsColumnId,
+        value: body
+      }
+    )
+  }
+
   if (recordingLink || faxDocLink) {
+
     const downloadUrl = recordingLink || faxDocLink
+
     const fileName =
-      messageType === 'Voicemail'
+      recordingLink
         ? `Voicemail-${Date.now()}.mp3`
         : `Fax-${Date.now()}.pdf`
 
@@ -1054,12 +1143,14 @@ async function createMessageLog({
     logId: updateId,
     contactId: itemId,
     returnMessage: {
-      message: 'Message logged in Monday',
+      message: 'Message thread created',
       messageType: 'success',
       ttl: 1000
     }
   }
 }
+
+
 
 async function updateMessageLog({
   user,
@@ -1070,68 +1161,141 @@ async function updateMessageLog({
   faxDocLink,
   accessToken
 }) {
-  const resolvedAccessToken = accessToken || user?.accessToken
 
-  if (!existingMessageLog?.thirdPartyLogId) {
-    throw new Error('Missing message log id for Monday update')
-  }
+  const resolvedAccessToken =
+    accessToken || user?.accessToken
 
+  const company = await getCompanyByHostname({
+    hostname: user.dataValues.hostname
+  })
+
+  const boardId = company.tenantId
   const itemId = Number(contactInfo.id)
 
-  const messageType = recordingLink
-    ? 'Voicemail'
-    : faxDocLink
-      ? 'Fax'
-      : 'SMS'
+  const updateId = existingMessageLog.thirdPartyLogId
 
-  let subject = ''
-  let body = ''
+  const callLogsColumnId = await getOrCreateCallLogsColumn({
+    accessToken: resolvedAccessToken,
+    boardId,
+    columnName: 'Call Logs'
+  })
 
-  switch (messageType) {
-    case 'SMS':
-      subject = `SMS conversation with ${contactInfo.name}`
-      body =
-        `SMS ${message.direction === 'Inbound' ? 'from' : 'to'} ${contactInfo.name}\n` +
-        `Message: ${message.subject || message.text || ''}`
-      break
-
-    case 'Voicemail':
-      subject = `Voicemail from ${contactInfo.name}`
-      body = `Voicemail updated`
-      break
-
-    case 'Fax':
-      subject = `Fax from ${contactInfo.name}`
-      body = `Fax document updated`
-      break
-  }
-
-  const fullBody = `${subject}\n${body}`
-
-  
-  const res = await mondayRequest(
+  const existing = await mondayRequest(
     resolvedAccessToken,
     `
-    mutation ($updateId: ID!, $body: String!) {
-      edit_update(id: $updateId, body: $body) {
+    query ($updateId: [ID!]) {
+      updates(ids: $updateId) {
         id
+        body
       }
     }
     `,
-    {
-      updateId: existingMessageLog.thirdPartyLogId,
-      body: fullBody
-    }
+    { updateId: [updateId] }
   )
 
-  if (!res?.data?.edit_update?.id) {
-    throw new Error('Failed to update message log in Monday')
+  let previousBody =
+    existing?.data?.updates?.[0]?.body || ''
+
+  const sender =
+    message.direction === 'Inbound'
+      ? contactInfo.name
+      : 'You'
+
+  const text = message.subject || message.text || ''
+
+  let newLine =
+`\n[${moment().format('YYYY-MM-DD HH:mm:ss')}] ${sender}: ${text}\n`
+
+  if (recordingLink) {
+    newLine += `Recording:\n${recordingLink}\n`
+  }
+
+  if (faxDocLink) {
+    newLine += `Fax Document:\n${faxDocLink}\n`
+  }
+
+  let updatedBody = previousBody + newLine
+
+  const messageCount =
+    updatedBody.split('\n')
+      .filter(l => l.includes(':'))
+      .length
+
+  let updateResponse
+
+  if (messageCount > MAX_THREAD_MESSAGES) {
+
+    let newThread =
+      `SMS conversation with ${contactInfo.name}\n`
+
+    newThread +=
+      `[${moment().format('YYYY-MM-DD HH:mm:ss')}] ${sender}: ${text}\n`
+
+    updateResponse = await mondayRequest(
+      resolvedAccessToken,
+      `
+      mutation ($itemId: ID!, $body: String!) {
+        create_update(item_id: $itemId, body: $body) {
+          id
+        }
+      }
+      `,
+      {
+        itemId,
+        body: newThread
+      }
+    )
+
+    updatedBody = newThread
+
+  } else {
+
+    updateResponse = await mondayRequest(
+      resolvedAccessToken,
+      `
+      mutation ($updateId: ID!, $body: String!) {
+        edit_update(id: $updateId, body: $body) {
+          id
+        }
+      }
+      `,
+      {
+        updateId,
+        body: updatedBody
+      }
+    )
+  }
+
+  if (callLogsColumnId) {
+    await mondayRequest(
+      resolvedAccessToken,
+      `
+      mutation ($boardId: ID!, $itemId: ID!, $columnId: String!, $value: String!) {
+        change_simple_column_value(
+          board_id: $boardId,
+          item_id: $itemId,
+          column_id: $columnId,
+          value: $value
+        ) {
+          id
+        }
+      }
+      `,
+      {
+        boardId,
+        itemId,
+        columnId: callLogsColumnId,
+        value: updatedBody
+      }
+    )
   }
 
   if (recordingLink || faxDocLink) {
+
     const downloadUrl = recordingLink || faxDocLink
+
     const fileName =
-      messageType === 'Voicemail'
+      recordingLink
         ? `Voicemail-${Date.now()}.mp3`
         : `Fax-${Date.now()}.pdf`
 
@@ -1153,9 +1317,11 @@ async function updateMessageLog({
   }
 
   return {
-    logId: res.data.edit_update.id,
+    logId:
+      updateResponse?.data?.edit_update?.id ||
+      updateResponse?.data?.create_update?.id,
     returnMessage: {
-      message: 'Message updated in Monday',
+      message: 'Message appended',
       messageType: 'success',
       ttl: 1000
     }

--- a/src/adapters/monday/index.js
+++ b/src/adapters/monday/index.js
@@ -567,77 +567,10 @@ async function findContact({ phoneNumber, accessToken, authHeader, user }) {
   }
 }
 
-async function findContactWithName({ name, accessToken, authHeader, user }) {
-
-  const company = await getCompanyByHostname({
-    hostname: user.dataValues.hostname
-  })
-
-  const boardId = company.tenantId
-
-  const resolvedAccessToken =
-    authHeader?.replace('Bearer ', '') || accessToken || user?.accessToken
-
-  const matchedContactInfo = []
-
-  if (!name) {
-    return {
-      successful: true,
-      matchedContactInfo: []
-    }
-  }
-
-  const res = await mondayRequest(
-    resolvedAccessToken,
-    `
-    query ($boardId: [ID!]) {
-      boards(ids: $boardId) {
-        items_page(limit: 50) {
-          items {
-            id
-            name
-          }
-        }
-      }
-    }
-    `,
-    { boardId: Number(boardId) }
-  )
-
-  const items =
-    res?.data?.boards?.[0]?.items_page?.items || []
-
-  if (res?.errors?.length) {
-    return {
-      successful: false,
-      returnMessage: {
-        messageType: 'error',
-        message: res?.errors?.[0]?.message || 'Failed to fetch contacts from Monday.',
-        ttl: 3000
-      }
-    }
-  }
-
-  const searchName = name.toLowerCase()
-
-  for (const item of items) {
-    if (item.name?.toLowerCase().includes(searchName)) {
-      matchedContactInfo.push({
-        id: item.id,
-        name: item.name
-      })
-    }
-  }
-
-  matchedContactInfo.push({
-    id: 'createNewContact',
-    name: 'Create new contact...',
-    isNewContact: true
-  })
-
+async function findContactWithName() {
   return {
     successful: true,
-    matchedContactInfo
+    matchedContactInfo: []
   }
 }
 

--- a/src/adapters/servicetitan/index.js
+++ b/src/adapters/servicetitan/index.js
@@ -442,17 +442,6 @@ function stripHtml(html = '') {
     .trim();
 }
 
-function formatCallDetails(details = '') {
-    return details
-        .replace(/Summary:/gi, '\nSummary:')
-        .replace(/Date\/time:/gi, '\nDate/Time:')
-        .replace(/Duration:/gi, '\nDuration:')
-        .replace(/Result:/gi, '\nResult:')
-        .replace(/Agent Notes/gi, '\nAgent Notes:')
-        .trim();
-}
-
-
 
 async function createCallLog({ user, contactInfo, callLog, note, additionalSubmission, aiNote, transcript, composedLogDetails, hashedAccountId }) {
 
@@ -467,11 +456,12 @@ async function createCallLog({ user, contactInfo, callLog, note, additionalSubmi
         ?? `${callLog.direction} Call ${callLog.direction === 'Outbound' ? 'to' : 'from'} ${contactInfo.name}`;
 
     let description = composedLogDetails;
-    
+    console.log("description", description)
+
     description = stripHtml(description)
-    description = formatCallDetails(description)
+
     // if (note) description += `<li><b>Subject</b><br>${subject}</li>`;
-    if (note) description += `\nAgent Notes: ${note}\n`;
+    if (note) description += `Agent Notes ${note}\n`;
     if (aiNote && (user.userSettings?.addCallLogAiNote?.value ?? true))
         description += `AI Note ${aiNote}\n`;
     if (transcript && (user.userSettings?.addCallLogTranscript?.value ?? true))
@@ -573,12 +563,14 @@ async function updateCallLog({ user, existingCallLog, authHeader, recordingLink,
     const stAppKey = user.dataValues.platformAdditionalInfo.st_app_key;
 
     let description = composedLogDetails;
+    console.log("update description", description)
+    console.log("existingCallLog", existingCallLog)
+    console.log("existingCallLogDetails", existingCallLogDetails)
 
     description = stripHtml(description)
-    description = formatCallDetails(description)
 
     // if (note) description += `\n\nSubject</b><br>${subject}`;
-    if (note) description += `\nAgent Notes: ${note}\n`;
+    if (note) description += `Agent Notes ${note}\n`;
     if (aiNote && (user.userSettings?.addCallLogAiNote?.value ?? true))
         description += `AI Note ${aiNote}\n`;
     if (transcript && (user.userSettings?.addCallLogTranscript?.value ?? true))

--- a/src/adapters/servicetitan/index.js
+++ b/src/adapters/servicetitan/index.js
@@ -442,6 +442,17 @@ function stripHtml(html = '') {
     .trim();
 }
 
+function formatCallDetails(details = '') {
+    return details
+        .replace(/Summary:/gi, '\nSummary:')
+        .replace(/Date\/time:/gi, '\nDate/Time:')
+        .replace(/Duration:/gi, '\nDuration:')
+        .replace(/Result:/gi, '\nResult:')
+        .replace(/Agent Notes/gi, '\nAgent Notes:')
+        .trim();
+}
+
+
 
 async function createCallLog({ user, contactInfo, callLog, note, additionalSubmission, aiNote, transcript, composedLogDetails, hashedAccountId }) {
 
@@ -456,12 +467,11 @@ async function createCallLog({ user, contactInfo, callLog, note, additionalSubmi
         ?? `${callLog.direction} Call ${callLog.direction === 'Outbound' ? 'to' : 'from'} ${contactInfo.name}`;
 
     let description = composedLogDetails;
-    console.log("description", description)
-
+    
     description = stripHtml(description)
-
+    description = formatCallDetails(description)
     // if (note) description += `<li><b>Subject</b><br>${subject}</li>`;
-    if (note) description += `Agent Notes ${note}\n`;
+    if (note) description += `\nAgent Notes: ${note}\n`;
     if (aiNote && (user.userSettings?.addCallLogAiNote?.value ?? true))
         description += `AI Note ${aiNote}\n`;
     if (transcript && (user.userSettings?.addCallLogTranscript?.value ?? true))
@@ -563,14 +573,12 @@ async function updateCallLog({ user, existingCallLog, authHeader, recordingLink,
     const stAppKey = user.dataValues.platformAdditionalInfo.st_app_key;
 
     let description = composedLogDetails;
-    console.log("update description", description)
-    console.log("existingCallLog", existingCallLog)
-    console.log("existingCallLogDetails", existingCallLogDetails)
 
     description = stripHtml(description)
+    description = formatCallDetails(description)
 
     // if (note) description += `\n\nSubject</b><br>${subject}`;
-    if (note) description += `Agent Notes ${note}\n`;
+    if (note) description += `\nAgent Notes: ${note}\n`;
     if (aiNote && (user.userSettings?.addCallLogAiNote?.value ?? true))
         description += `AI Note ${aiNote}\n`;
     if (transcript && (user.userSettings?.addCallLogTranscript?.value ?? true))

--- a/src/adapters/servicetitan/manifest.json
+++ b/src/adapters/servicetitan/manifest.json
@@ -129,6 +129,12 @@
                             "title": "Deals",
                             "type": "selection",
                             "contactDependent": true
+                        },
+                        {
+                            "const": "address",
+                            "title": "Address",
+                            "type": "inputField",
+                            "contactDependent": false
                         }
                     ]
                 },
@@ -139,6 +145,12 @@
                             "title": "Deals",
                             "type": "selection",
                             "contactDependent": true
+                        },
+                        {
+                            "const": "address",
+                            "title": "Address",
+                            "type": "inputField",
+                            "contactDependent": false
                         }
                     ]
                 }

--- a/src/adapters/servicetitan/manifest.json
+++ b/src/adapters/servicetitan/manifest.json
@@ -129,12 +129,6 @@
                             "title": "Deals",
                             "type": "selection",
                             "contactDependent": true
-                        },
-                        {
-                            "const": "address",
-                            "title": "Address",
-                            "type": "inputField",
-                            "contactDependent": false
                         }
                     ]
                 },
@@ -145,12 +139,6 @@
                             "title": "Deals",
                             "type": "selection",
                             "contactDependent": true
-                        },
-                        {
-                            "const": "address",
-                            "title": "Address",
-                            "type": "inputField",
-                            "contactDependent": false
                         }
                     ]
                 }


### PR DESCRIPTION
This PR enhances the SMS message logging functionality in the Monday adapter to behave similar to the existing Call Logs implementation.

Changes :

1. Thread-based SMS logging:
a) createMessageLog creates a new conversation thread in Monday.
b) updateMessageLog appends new messages to the existing thread instead of replacing previous logs.

2. Call Logs column sync:
a) SMS conversation content is also written to the Call Logs column, same as call logs.

3. Recording and Fax handling:
a) If a recording link or fax document is present, the file is downloaded and uploaded to the Monday Files column.

4. Conversation limit:
a) Each thread stores up to 10 messages.
b) If the conversation exceeds this limit, a new thread is automatically created.

5. Consistent behaviour with Call Logs:
a) Message logging now follows the same structure and utilities used in createCallLog and updateCallLog.

Result:
SMS conversations, voicemail recordings, and fax documents are now properly logged in Monday with threaded history, file uploads, and synchronized call log entries.