### PR TITLE
fix: replace default account assignment with dynamic account lookup by name

### DIFF
--- a/src/adapters/servicenow-core/interaction.js
+++ b/src/adapters/servicenow-core/interaction.js
@@ -193,21 +193,24 @@ async function findTypeValueById(hostname, authHeader, inputId) {
     
 }
 
-async function findAccountByName(hostname, authHeader, inputValue) {
-    try {
-        console.log("findAccountByName called with:", inputValue);
+function findAccountByNameFromList(accounts, inputValue) {
+    const sanitizedInput = (inputValue || '').trim();
+    if (!sanitizedInput) return null;
 
-        const sanitizedInput = (inputValue || '').trim();
-        if (!sanitizedInput) {
-            return null;
+    const collapseLabel = (val = '') => val.toLowerCase().replace(/\s+/g, '');
+    const collapsedInput = collapseLabel(sanitizedInput);
+
+    for (const acc of accounts) {
+        if (collapseLabel(acc.name || '') === collapsedInput) {
+            return acc.sys_id;
         }
+    }
 
-        // collapse spaces + lowercase
-        const collapseLabel = (val = '') => val.toLowerCase().replace(/\s+/g, '');
+    return null;
+}
 
-        const collapsedInput = collapseLabel(sanitizedInput);
-
-        // fetch accounts
+async function getAllAccounts(hostname, authHeader) {
+    try {
         const response = await axios.get(
             `https://${hostname}/api/now/account`,
             {
@@ -215,27 +218,16 @@ async function findAccountByName(hostname, authHeader, inputValue) {
             }
         );
 
-        const accounts = response.data?.result || [];
-
-        for (const acc of accounts) {
-            const collapsedAccount = collapseLabel(acc.name);
-
-            if (collapsedAccount === collapsedInput) {
-                return acc.sys_id;
-            }
-        }
-
-        return null;
-
+        return response.data?.result || [];
     } catch (error) {
-        console.log("Error in findAccountByName:", error);
-        return null;
+        console.log("Error fetching accounts:", error);
+        return [];
     }
 }
-
 
 exports.findStateValueByName = findStateValueByName;
 exports.findStateValueById = findStateValueById;
 exports.findTypeValueByName = findTypeValueByName;
 exports.findTypeValueById = findTypeValueById;
-exports.findAccountByName = findAccountByName;
+exports.findAccountByNameFromList = findAccountByNameFromList;
+exports.getAllAccounts = getAllAccounts;

--- a/src/adapters/servicenow-core/interaction.js
+++ b/src/adapters/servicenow-core/interaction.js
@@ -193,8 +193,49 @@ async function findTypeValueById(hostname, authHeader, inputId) {
     
 }
 
+async function findAccountByName(hostname, authHeader, inputValue) {
+    try {
+        console.log("findAccountByName called with:", inputValue);
+
+        const sanitizedInput = (inputValue || '').trim();
+        if (!sanitizedInput) {
+            return null;
+        }
+
+        // collapse spaces + lowercase
+        const collapseLabel = (val = '') => val.toLowerCase().replace(/\s+/g, '');
+
+        const collapsedInput = collapseLabel(sanitizedInput);
+
+        // fetch accounts
+        const response = await axios.get(
+            `https://${hostname}/api/now/account`,
+            {
+                headers: { Authorization: authHeader }
+            }
+        );
+
+        const accounts = response.data?.result || [];
+
+        for (const acc of accounts) {
+            const collapsedAccount = collapseLabel(acc.name);
+
+            if (collapsedAccount === collapsedInput) {
+                return acc.sys_id;
+            }
+        }
+
+        return null;
+
+    } catch (error) {
+        console.log("Error in findAccountByName:", error);
+        return null;
+    }
+}
+
 
 exports.findStateValueByName = findStateValueByName;
 exports.findStateValueById = findStateValueById;
 exports.findTypeValueByName = findTypeValueByName;
 exports.findTypeValueById = findTypeValueById;
+exports.findAccountByName = findAccountByName;

--- a/src/adapters/servicenow/index.js
+++ b/src/adapters/servicenow/index.js
@@ -2,7 +2,7 @@ const axios = require('axios');
 const moment = require('moment');
 const { parsePhoneNumber } = require('awesome-phonenumber');
 const { saveUserInfo } = require('../servicenow-core/auth');
-const { findStateValueByName, findStateValueById, findTypeValueByName, findTypeValueById } = require('../servicenow-core/interaction');
+const { findStateValueByName, findStateValueById, findTypeValueByName, findTypeValueById, findAccountByName } = require('../servicenow-core/interaction');
 const { UserModel } = require('@app-connect/core/models/userModel');
 const Op = require('sequelize').Op;
 const { initModels } = require('../servicenow-models/init-models');
@@ -1049,7 +1049,8 @@ async function updateMessageLog({ user, contactInfo, existingMessageLog, message
     };
 }
 
-async function createContact({ user, authHeader, phoneNumber, newContactName, newContactType }) {
+async function createContact({ user, authHeader, phoneNumber, newContactName, newContactType, additionalSubmission }) {
+    console.log("Additional Submission", additionalSubmission)
     // ----------------------------------------
     // ---TODO.9: Implement contact creation---
     // ----------------------------------------
@@ -1059,6 +1060,7 @@ async function createContact({ user, authHeader, phoneNumber, newContactName, ne
     const userInfo = await getHostname(user.dataValues.hostname);
     const instanceId = userInfo.instanceId;
     const hostname = userInfo.hostname;
+    const accountName = additionalSubmission?.accountName;
 
     const companyData = await models.companies.findOne({
         where: {
@@ -1076,13 +1078,15 @@ async function createContact({ user, authHeader, phoneNumber, newContactName, ne
     const isExtensionNumber = phoneNumber.toString().length <= 8 && phoneNumber.toString().length >= 3;
 
     if (companyData?.contactTable == 'contact' && !isExtensionNumber) {
-        const account = await axios.get(`https://${hostname}/api/now/account`, {
-            headers: {
-                'Authorization': authHeader
-            }
-        });
+        if (accountName) {
+            const accountId = await findAccountByName(hostname, authHeader, accountName);
 
-        postBody.account = account.data.result[0].sys_id;
+            if (accountId) {
+                postBody.account = accountId;
+            } else {
+                console.log("No matching account found for:", accountName);
+            }
+        }
         postBody.name = newContactName?.toLowerCase();
         contactInfoRes = await axios.post(
             `https://${hostname}/api/now/contact`,

--- a/src/adapters/servicenow/index.js
+++ b/src/adapters/servicenow/index.js
@@ -2,7 +2,7 @@ const axios = require('axios');
 const moment = require('moment');
 const { parsePhoneNumber } = require('awesome-phonenumber');
 const { saveUserInfo } = require('../servicenow-core/auth');
-const { findStateValueByName, findStateValueById, findTypeValueByName, findTypeValueById, findAccountByName } = require('../servicenow-core/interaction');
+const { findStateValueByName, findStateValueById, findTypeValueByName, findTypeValueById, findAccountByNameFromList, getAllAccounts } = require('../servicenow-core/interaction');
 const { UserModel } = require('@app-connect/core/models/userModel');
 const Op = require('sequelize').Op;
 const { initModels } = require('../servicenow-models/init-models');
@@ -403,6 +403,25 @@ async function unAuthorize({ user }) {
     //--------------------------------------------------------------
 }
 
+function generateFormatsFromE164(e164Number) {
+    const digits = e164Number.replace(/\D/g, '');
+
+    // assume US (1 + 10 digits)
+    if (digits.length === 11 && digits.startsWith('1')) {
+        const d = digits.slice(1);
+
+        return [
+            e164Number,                 // +18003534676
+            digits,                     // 18003534676
+            d,                          // 8003534676
+            `(${d.slice(0,3)}) ${d.slice(3,6)}-${d.slice(6)}`, // (800) 353-4676
+            `${d.slice(0,3)}-${d.slice(3,6)}-${d.slice(6)}`    // 800-353-4676
+        ];
+    }
+
+    return [e164Number];
+}
+
 async function findContact({ user, authHeader, phoneNumber, overridingFormat, isExtension }) {
     // ----------------------------------------
     // ---TODO.3: Implement contact matching---
@@ -410,30 +429,15 @@ async function findContact({ user, authHeader, phoneNumber, overridingFormat, is
     const licenseError = await validateLicenseOrFail(user);
     if (licenseError) return licenseError;
 
-    const numberToQueryArray = [];
     console.log("authHeader", authHeader)
+    let numberToQueryArray = [];
 
-    if (overridingFormat === '') {
-        numberToQueryArray.push(phoneNumber.replace(/^\+/, ''));
-    }
-    else {
-        const formats = overridingFormat.split(',');
-        for (var format of formats) {
-            let phoneNumberObj;
-            if(isExtension) {
-                numberToQueryArray.push(phoneNumber);
-            } else {
-                phoneNumberObj = parsePhoneNumber(phoneNumber.replace(' ', '+'));
-                if (phoneNumberObj.valid) {
-                    const phoneNumberWithoutCountryCode = phoneNumberObj.number.significant;
-                    let formattedNumber = format;
-                    for (const numberBit of phoneNumberWithoutCountryCode) {
-                        formattedNumber = formattedNumber.replace('*', numberBit);
-                    }
-                    numberToQueryArray.push(formattedNumber);
-                }
-            }
-        }
+    const isRealExtension = isExtension === true || isExtension === 'true';
+
+    if (isRealExtension && phoneNumber.length <= 8) {
+        numberToQueryArray = [phoneNumber];
+    } else {
+        numberToQueryArray = generateFormatsFromE164(phoneNumber);
     }
 
     const userInfo = await getHostname(user.dataValues.hostname);
@@ -468,7 +472,7 @@ async function findContact({ user, authHeader, phoneNumber, overridingFormat, is
     const matchedContactInfo = [];
     const isExtensionBool = isExtension === true || isExtension === 'true';
     const contactTable = (companyData?.contactTable?.trim().toLowerCase() == 'user' || isExtensionBool) ? 'table/sys_user' : 'contact';
-
+    
     for (var numberToQuery of numberToQueryArray) {
         const personInfo = await axios.get(
             `https://${hostname}/api/now/${contactTable}?sysparm_query=phoneLIKE${numberToQuery}^ORmobile_phoneLIKE${numberToQuery}`,
@@ -1059,7 +1063,6 @@ async function createContact({ user, authHeader, phoneNumber, newContactName, ne
     const userInfo = await getHostname(user.dataValues.hostname);
     const instanceId = userInfo.instanceId;
     const hostname = userInfo.hostname;
-    const accountName = additionalSubmission?.accountName;
 
     const companyData = await models.companies.findOne({
         where: {
@@ -1077,15 +1080,25 @@ async function createContact({ user, authHeader, phoneNumber, newContactName, ne
     const isExtensionNumber = phoneNumber.toString().length <= 8 && phoneNumber.toString().length >= 3;
 
     if (companyData?.contactTable == 'contact' && !isExtensionNumber) {
-        if (accountName) {
-            const accountId = await findAccountByName(hostname, authHeader, accountName);
+        const accountName = additionalSubmission?.accountName;
+        const accounts = await getAllAccounts(hostname, authHeader);
+        let accountId = null;
 
-            if (accountId) {
-                postBody.account = accountId;
-            } else {
-                console.log("No matching account found for:", accountName);
+        if (!accountName || accountName.trim() === '') {
+            accountId = accounts[0]?.sys_id;
+        } else {
+            accountId = findAccountByNameFromList(accounts, accountName);
+
+            if (!accountId) {
+                console.log("No match found, falling back");
+                accountId = accounts[0]?.sys_id;
             }
         }
+
+        if (accountId){
+            postBody.account = accountId;
+        }
+
         postBody.name = newContactName?.toLowerCase();
         contactInfoRes = await axios.post(
             `https://${hostname}/api/now/contact`,

--- a/src/adapters/servicenow/index.js
+++ b/src/adapters/servicenow/index.js
@@ -1050,7 +1050,6 @@ async function updateMessageLog({ user, contactInfo, existingMessageLog, message
 }
 
 async function createContact({ user, authHeader, phoneNumber, newContactName, newContactType, additionalSubmission }) {
-    console.log("Additional Submission", additionalSubmission)
     // ----------------------------------------
     // ---TODO.9: Implement contact creation---
     // ----------------------------------------

--- a/src/adapters/servicenow/manifest.json
+++ b/src/adapters/servicenow/manifest.json
@@ -133,6 +133,16 @@
                 }
             ],
             "page": {
+                "newContact": {
+                    "additionalFields": [
+                        {
+                            "const": "accountName",
+                            "title": "Account Name",
+                            "type": "inputField",
+                            "placeholder": "Enter account name"
+                        }
+                    ]
+                },
                 "callLog": {
                     "additionalFields": [
                         {


### PR DESCRIPTION
1. Removed hardcoded first account mapping
2. Added findAccountByName for normalized (case & spacing insensitive) matching
3. Assign account based on user input during contact creation