### PR TITLE
fix: opened_at, sys_choice, closed state

### DIFF
--- a/src/adapters/servicenow-core/interaction.js
+++ b/src/adapters/servicenow-core/interaction.js
@@ -1,4 +1,5 @@
 const axios = require('axios');
+const moment = require('moment');
 const serviceNowApiClient = axios.create();
 
 function stringifyForLog(value, maxLength = 1200) {
@@ -240,8 +241,53 @@ async function getAllAccounts(hostname, authHeader) {
     }
 }
 
+function isClosedInteractionState(stateValue) {
+    const normalized = (stateValue || '').toString().trim().toLowerCase();
+    return normalized === 'closed_complete' || normalized === 'closed_abandoned';
+}
+
+function toServiceNowUtcDateTime(valueMs) {
+    const numericMs = Number(valueMs);
+    if (!Number.isFinite(numericMs) || numericMs <= 0) {
+        return moment.utc().format('YYYY-MM-DD HH:mm:ss');
+    }
+    return moment.utc(numericMs).format('YYYY-MM-DD HH:mm:ss');
+}
+
+function applyClosedDatesIfNeeded(payload, stateValue, callLog) {
+    if (!isClosedInteractionState(stateValue)) {
+        return;
+    }
+
+    const startTimeMs = Number(callLog?.startTime);
+    const durationMs = Number(callLog?.durationMs);
+    const durationSec = Number(callLog?.duration);
+    const computedDurationMs = Number.isFinite(durationMs) && durationMs > 0
+        ? durationMs
+        : (Number.isFinite(durationSec) && durationSec > 0 ? durationSec * 1000 : 1000);
+
+    if (Number.isFinite(startTimeMs) && startTimeMs > 0) {
+        if (!payload.opened_at) {
+            payload.opened_at = toServiceNowUtcDateTime(startTimeMs);
+        }
+        if (!payload.closed_at) {
+            payload.closed_at = toServiceNowUtcDateTime(startTimeMs + computedDurationMs);
+        }
+        return;
+    }
+
+    const nowMs = Date.now();
+    if (!payload.opened_at) {
+        payload.opened_at = toServiceNowUtcDateTime(nowMs - 1000);
+    }
+    if (!payload.closed_at) {
+        payload.closed_at = toServiceNowUtcDateTime(nowMs);
+    }
+}
+
 exports.findStateValueByName = findStateValueByName;
 exports.findStateValueById = findStateValueById;
 exports.findTypeValueByName = findTypeValueByName;
 exports.findTypeValueById = findTypeValueById;
 exports.getAllAccounts = getAllAccounts;
+exports.applyClosedDatesIfNeeded = applyClosedDatesIfNeeded;

--- a/src/adapters/servicenow/index.js
+++ b/src/adapters/servicenow/index.js
@@ -2,7 +2,7 @@ const axios = require('axios');
 const moment = require('moment');
 const { parsePhoneNumber } = require('awesome-phonenumber');
 const { saveUserInfo } = require('../servicenow-core/auth');
-const { findStateValueByName, findStateValueById, findTypeValueByName, findTypeValueById, getAllAccounts } = require('../servicenow-core/interaction');
+const { findStateValueByName, findStateValueById, findTypeValueByName, findTypeValueById, getAllAccounts, applyClosedDatesIfNeeded } = require('../servicenow-core/interaction');
 const { UserModel } = require('@app-connect/core/models/userModel');
 const Op = require('sequelize').Op;
 const { initModels } = require('../servicenow-models/init-models');
@@ -424,23 +424,27 @@ async function findContact({ user, authHeader, phoneNumber, overridingFormat, is
             }
         };
     }
-
-    const stateSelection = await serviceNowApiClient.get(
-        `https://${hostname}/api/now/table/sys_choice?sysparm_query=name=interaction^element=state&sysparm_fields=sys_id,label,value`,
-        {
-            headers: { 'Authorization':  authHeader }
-        });
     
-    const typeSelection = await serviceNowApiClient.get(
-        `https://${hostname}/api/now/table/sys_choice?sysparm_query=name=interaction^element=type&sysparm_fields=sys_id,label,value`,
-        {
-            headers: { 'Authorization':  authHeader }
-        });
-
-    const states = stateSelection.data.result.length > 0 ? stateSelection.data.result.map(m => { return { const: m.sys_id, title: m.label } }) : null;
-
-    const interactionType = typeSelection.data.result.length > 0 ? typeSelection.data.result.map(m => { return { const: m.sys_id, title: m.label } }) : null;
-    
+    let states = [];
+    let interactionType = [];
+    try {
+        const stateSelection = await serviceNowApiClient.get(
+            `https://${hostname}/api/now/table/sys_choice?sysparm_query=name=interaction^element=state&sysparm_fields=sys_id,label,value`,
+            { headers: { 'Authorization': authHeader } }
+        );
+        states = stateSelection.data.result.length > 0 ? stateSelection.data.result.map(m => { return { const: m.sys_id, title: m.label } }) : [];
+    } catch (err) {
+        console.log('sys_choice state lookup failed, continuing without state options:', err.response?.status);
+    }
+    try {
+        const typeSelection = await serviceNowApiClient.get(
+            `https://${hostname}/api/now/table/sys_choice?sysparm_query=name=interaction^element=type&sysparm_fields=sys_id,label,value`,
+            { headers: { 'Authorization': authHeader } }
+        );
+        interactionType = typeSelection.data.result.length > 0 ? typeSelection.data.result.map(m => { return { const: m.sys_id, title: m.label } }) : [];
+    } catch (err) {
+        console.log('sys_choice type lookup failed, continuing without type options:', err.response?.status);
+    }
 
     // You can use parsePhoneNumber functions to further parse the phone number
     const matchedContactInfo = [];
@@ -462,11 +466,18 @@ async function findContact({ user, authHeader, phoneNumber, overridingFormat, is
                     continue;
                 }
                 matchedContactIds.add(contactId);
+                const additionalInfo = {};
+                if (states.length > 0) {
+                    additionalInfo.state = states;
+                }
+                if (interactionType.length > 0) {
+                    additionalInfo.type = interactionType;
+                }
                 matchedContactInfo.push({
                     id: contactId,
                     name: (contactTable == 'table/sys_user') ? result.user_name : result.name,
                     phone: numberToQuery,
-                    additionalInfo: {state: states, type: interactionType}
+                    additionalInfo
                 })
             }
         }
@@ -583,12 +594,16 @@ async function createCallLog({ user, contactInfo, authHeader, callLog, note, add
     }
 
     postBody.assigned_to = caller_id.data.result.id;
+    if (callLog?.startTime) {
+        postBody.opened_at = callLog.startTime;
+    }
 
     console.log("additionalSubmission", additionalSubmission)
 
     if (additionalSubmission?.state) {
         const returnedState = await findStateValueById(hostname, authHeader, additionalSubmission.state);
         postBody.state = returnedState ?? await findStateValueByName(hostname, authHeader, additionalSubmission.state);
+        applyClosedDatesIfNeeded(postBody, postBody.state, callLog);
     }
 
     postBody.opened_for = contactInfo.id;

--- a/src/adapters/servicenow/manifest.json
+++ b/src/adapters/servicenow/manifest.json
@@ -149,7 +149,7 @@
                             "title": "State",
                             "type": "selection",
                             "contactDependent": true,
-                            "allowCustomValue": true,
+                            "allowCustomValue": false,
                             "defaultSettingId": "serviceNowState",
                             "defaultSettingValues": {
                                 "inboundCall": {
@@ -165,7 +165,7 @@
                             "title": "Type",
                             "type": "selection",
                             "contactDependent": true,
-                            "allowCustomValue": true,
+                            "allowCustomValue": false,
                             "defaultSettingId": "serviceNowType",
                             "defaultSettingValues": {
                                 "inboundCall": {


### PR DESCRIPTION
1. Fixed opened time, now in ServiceNow's interaction table, user will see the date and time of call instead of date and time of call log created in opened column.
2. Made sys_choice an optional API call, if it will fail user will not see the state or type or both dropdown.
3. resolved closed state problem now user can select closed option also in state dropdown.