### PR TITLE
added call duration

### DIFF
--- a/src/adapters/servicenow-core/interaction.js
+++ b/src/adapters/servicenow-core/interaction.js
@@ -285,6 +285,33 @@ function applyClosedDatesIfNeeded(payload, stateValue, callLog) {
     }
 }
 
+function formatDuration(seconds) {
+    seconds = Number(seconds);
+
+    if (seconds < 60) {
+        return `${seconds} Second${seconds !== 1 ? 's' : ''}`;
+    }
+
+    const hours = Math.floor(seconds / 3600);
+    const minutes = Math.floor((seconds % 3600) / 60);
+    const remainingSeconds = seconds % 60;
+
+    let result = '';
+
+    if (hours > 0) {
+        result += `${hours} Hour${hours !== 1 ? 's' : ''} `;
+    }
+
+    if (minutes > 0) {
+        result += `${minutes} Minute${minutes !== 1 ? 's' : ''} `;
+    }
+
+    if (remainingSeconds > 0) {
+        result += `${remainingSeconds} Second${remainingSeconds !== 1 ? 's' : ''}`;
+    }
+
+    return result.trim();
+}
 
 exports.findStateValueByName = findStateValueByName;
 exports.findStateValueById = findStateValueById;
@@ -292,3 +319,4 @@ exports.findTypeValueByName = findTypeValueByName;
 exports.findTypeValueById = findTypeValueById;
 exports.getAllAccounts = getAllAccounts;
 exports.applyClosedDatesIfNeeded = applyClosedDatesIfNeeded;
+exports.formatDuration = formatDuration;

--- a/src/adapters/servicenow/index.js
+++ b/src/adapters/servicenow/index.js
@@ -2,7 +2,7 @@ const axios = require('axios');
 const moment = require('moment');
 const { parsePhoneNumber } = require('awesome-phonenumber');
 const { saveUserInfo } = require('../servicenow-core/auth');
-const { findStateValueByName, findStateValueById, findTypeValueByName, findTypeValueById, getAllAccounts, applyClosedDatesIfNeeded } = require('../servicenow-core/interaction');
+const { findStateValueByName, findStateValueById, findTypeValueByName, findTypeValueById, getAllAccounts, applyClosedDatesIfNeeded, formatDuration } = require('../servicenow-core/interaction');
 const { UserModel } = require('@app-connect/core/models/userModel');
 const Op = require('sequelize').Op;
 const { initModels } = require('../servicenow-models/init-models');
@@ -754,6 +754,8 @@ async function createCallLog({ user, contactInfo, authHeader, callLog, note, add
     if (callLog?.startTime) {
         postBody.opened_at = callLog.startTime;
     }
+
+    postBody.u_actual_call_duration = formatDuration(callLog.duration);
 
     postBody.assigned_to = caller_id.data.result.id;
 


### PR DESCRIPTION
1. Added support for storing actual RingCentral call handling duration in ServiceNow interactions.
2. Implemented human-readable duration formatting (e.g. 7 Seconds, 2 Minutes 5 Seconds).