### PR TITLE
Added event analytics using GA

### DIFF
--- a/src/adapters/agencyzoom/index.js
+++ b/src/adapters/agencyzoom/index.js
@@ -8,6 +8,7 @@ const { UserModel } = require('@app-connect/core/models/userModel');
 const { CallLogModel } = require('@app-connect/core/models/callLogModel');
 const { sequelize } = require('../servicenow-models/sequelize');
 const { initModels } = require('../servicenow-models/init-models');
+const analytics = require('../servicenow-core/analytics');
 const models = initModels(sequelize);
 
 const AZ_BASE_URL = "https://api.agencyzoom.com/v1/api";
@@ -251,6 +252,11 @@ async function getUserInfo(authHeader) {
       });
     }
 
+    await analytics.trackUserConnected({
+      adapterName: 'agencyzoom',
+      companyIdentifier: hostname
+    });
+
     // Success response
     return {
       successful: true,
@@ -468,6 +474,11 @@ async function createContact({ user, phoneNumber, newContactName }) {
     }
   );
 
+  await analytics.trackContactCreated({
+    adapterName: 'agencyzoom',
+    companyIdentifier: user.hostname || user.dataValues?.hostname
+  });
+
   return {
     contactInfo: {
       id: res.data.id,
@@ -526,6 +537,13 @@ ${description}
     { note: noteBody },
     { headers: { Authorization: `Bearer ${auth}` } }
   );
+
+  await analytics.trackCallLogCreated({
+    adapterName: 'agencyzoom',
+    companyIdentifier: user.hostname || user.dataValues?.hostname,
+    callDirection: callLog.direction,
+    callDurationSeconds: callLog.duration
+  });
 
   return {
     logId,
@@ -632,6 +650,11 @@ ${description}
     { note: noteBody },
     { headers: { Authorization: `Bearer ${auth}` } }
   );
+
+  await analytics.trackCallLogUpdated({
+    adapterName: 'agencyzoom',
+    companyIdentifier: user.hostname || user.dataValues?.hostname
+  });
 
   return {
     logId,
@@ -798,6 +821,13 @@ ${description}
     { headers: { Authorization: `Bearer ${auth}` } }
   );
 
+  await analytics.trackMessageLogCreated({
+    adapterName: 'agencyzoom',
+    companyIdentifier: user.hostname || user.dataValues?.hostname,
+    recordingLink,
+    faxDocLink
+  });
+
   return {
     logId,
     contactId: Number(contactInfo.id),
@@ -902,6 +932,13 @@ ${updatedConversation}
     { note: noteBody },
     { headers: { Authorization: `Bearer ${auth}` } }
   );
+
+  await analytics.trackMessageLogUpdated({
+    adapterName: 'agencyzoom',
+    companyIdentifier: user.hostname || user.dataValues?.hostname,
+    recordingLink,
+    faxDocLink
+  });
 
   return {
     logId,

--- a/src/adapters/agencyzoom/index.js
+++ b/src/adapters/agencyzoom/index.js
@@ -11,6 +11,7 @@ const { initModels } = require('../servicenow-models/init-models');
 const analytics = require('../servicenow-core/analytics');
 const models = initModels(sequelize);
 
+const ADAPTER_NAME = 'agencyzoom';
 const AZ_BASE_URL = "https://api.agencyzoom.com/v1/api";
 
 async function getLicenseStatus({ userId }) {
@@ -253,7 +254,7 @@ async function getUserInfo(authHeader) {
     }
 
     await analytics.trackUserConnected({
-      adapterName: 'agencyzoom',
+      adapterName: ADAPTER_NAME,
       companyIdentifier: hostname
     });
 
@@ -475,7 +476,7 @@ async function createContact({ user, phoneNumber, newContactName }) {
   );
 
   await analytics.trackContactCreated({
-    adapterName: 'agencyzoom',
+    adapterName: ADAPTER_NAME,
     companyIdentifier: user.hostname || user.dataValues?.hostname
   });
 
@@ -539,7 +540,7 @@ ${description}
   );
 
   await analytics.trackCallLogCreated({
-    adapterName: 'agencyzoom',
+    adapterName: ADAPTER_NAME,
     companyIdentifier: user.hostname || user.dataValues?.hostname,
     callDirection: callLog.direction,
     callDurationSeconds: callLog.duration
@@ -652,7 +653,7 @@ ${description}
   );
 
   await analytics.trackCallLogUpdated({
-    adapterName: 'agencyzoom',
+    adapterName: ADAPTER_NAME,
     companyIdentifier: user.hostname || user.dataValues?.hostname
   });
 
@@ -822,7 +823,7 @@ ${description}
   );
 
   await analytics.trackMessageLogCreated({
-    adapterName: 'agencyzoom',
+    adapterName: ADAPTER_NAME,
     companyIdentifier: user.hostname || user.dataValues?.hostname,
     recordingLink,
     faxDocLink
@@ -934,7 +935,7 @@ ${updatedConversation}
   );
 
   await analytics.trackMessageLogUpdated({
-    adapterName: 'agencyzoom',
+    adapterName: ADAPTER_NAME,
     companyIdentifier: user.hostname || user.dataValues?.hostname,
     recordingLink,
     faxDocLink

--- a/src/adapters/monday/index.js
+++ b/src/adapters/monday/index.js
@@ -8,6 +8,7 @@ const models = initModels(sequelize);
 const FormData = require('form-data')
 const s3Helper = require('../servicenow-core/s3');
 const AWS = require('aws-sdk');
+const analytics = require('../servicenow-core/analytics');
 
 const MONDAY_API_URL = process.env.MONDAY_API_URL;
 const MONDAY_AUTHORIZE_URL = process.env.MONDAY_AUTHORIZE_URL;
@@ -421,6 +422,11 @@ async function getUserInfo({ authHeader, hostname, query }) {
       });
     }
 
+    await analytics.trackUserConnected({
+      adapterName: 'monday',
+      companyIdentifier: hostname
+    });
+
     return {
       successful: true,
       platformUserInfo: {
@@ -645,6 +651,11 @@ async function createContact({ phoneNumber, newContactName, accessToken, authHea
     }
   )
 
+  await analytics.trackContactCreated({
+    adapterName: 'monday',
+    companyIdentifier: user.hostname || user.dataValues?.hostname
+  })
+
   return {
     contactInfo: {
       id: res.data.create_item.id,
@@ -742,6 +753,13 @@ async function createCallLog({ contactInfo, callLog, note, aiNote, transcript, a
     })
   }
 
+  await analytics.trackCallLogCreated({
+    adapterName: 'monday',
+    companyIdentifier: user.hostname || user.dataValues?.hostname,
+    callDirection: callLog.direction,
+    callDurationSeconds: callLog.duration
+  })
+
   return {
     logId: updateId,
     contactId: Number(contactInfo.id),
@@ -827,6 +845,11 @@ async function updateCallLog({ existingCallLog, recordingLink, note, aiNote, tra
       body
     }
   )
+
+  await analytics.trackCallLogUpdated({
+    adapterName: 'monday',
+    companyIdentifier: user.hostname || user.dataValues?.hostname
+  })
 
   return {
     logId: updateRes.data.edit_update.id,
@@ -1005,6 +1028,13 @@ async function createMessageLog({ user, contactInfo, message, recordingLink, fax
       hostname: user.dataValues.hostname
     })
   }
+
+  await analytics.trackMessageLogCreated({
+    adapterName: 'monday',
+    companyIdentifier: user.hostname || user.dataValues?.hostname,
+    recordingLink,
+    faxDocLink
+  })
 
   return {
     logId: updateId,
@@ -1208,6 +1238,13 @@ async function updateMessageLog({ user, contactInfo, existingMessageLog, message
       hostname: user.dataValues.hostname
     })
   }
+
+  await analytics.trackMessageLogUpdated({
+    adapterName: 'monday',
+    companyIdentifier: user.hostname || user.dataValues?.hostname,
+    recordingLink,
+    faxDocLink
+  })
 
   return {
     logId: newThreadId,

--- a/src/adapters/monday/index.js
+++ b/src/adapters/monday/index.js
@@ -10,6 +10,7 @@ const s3Helper = require('../servicenow-core/s3');
 const AWS = require('aws-sdk');
 const analytics = require('../servicenow-core/analytics');
 
+const ADAPTER_NAME = 'monday';
 const MONDAY_API_URL = process.env.MONDAY_API_URL;
 const MONDAY_AUTHORIZE_URL = process.env.MONDAY_AUTHORIZE_URL;
 var MONDAY_CLIENT_SECRET = '';
@@ -423,7 +424,7 @@ async function getUserInfo({ authHeader, hostname, query }) {
     }
 
     await analytics.trackUserConnected({
-      adapterName: 'monday',
+      adapterName: ADAPTER_NAME,
       companyIdentifier: hostname
     });
 
@@ -652,7 +653,7 @@ async function createContact({ phoneNumber, newContactName, accessToken, authHea
   )
 
   await analytics.trackContactCreated({
-    adapterName: 'monday',
+    adapterName: ADAPTER_NAME,
     companyIdentifier: user.hostname || user.dataValues?.hostname
   })
 
@@ -754,7 +755,7 @@ async function createCallLog({ contactInfo, callLog, note, aiNote, transcript, a
   }
 
   await analytics.trackCallLogCreated({
-    adapterName: 'monday',
+    adapterName: ADAPTER_NAME,
     companyIdentifier: user.hostname || user.dataValues?.hostname,
     callDirection: callLog.direction,
     callDurationSeconds: callLog.duration
@@ -847,7 +848,7 @@ async function updateCallLog({ existingCallLog, recordingLink, note, aiNote, tra
   )
 
   await analytics.trackCallLogUpdated({
-    adapterName: 'monday',
+    adapterName: ADAPTER_NAME,
     companyIdentifier: user.hostname || user.dataValues?.hostname
   })
 
@@ -1030,7 +1031,7 @@ async function createMessageLog({ user, contactInfo, message, recordingLink, fax
   }
 
   await analytics.trackMessageLogCreated({
-    adapterName: 'monday',
+    adapterName: ADAPTER_NAME,
     companyIdentifier: user.hostname || user.dataValues?.hostname,
     recordingLink,
     faxDocLink
@@ -1240,7 +1241,7 @@ async function updateMessageLog({ user, contactInfo, existingMessageLog, message
   }
 
   await analytics.trackMessageLogUpdated({
-    adapterName: 'monday',
+    adapterName: ADAPTER_NAME,
     companyIdentifier: user.hostname || user.dataValues?.hostname,
     recordingLink,
     faxDocLink

--- a/src/adapters/servicenow-core/analytics.js
+++ b/src/adapters/servicenow-core/analytics.js
@@ -1,0 +1,180 @@
+const axios = require('axios');
+const crypto = require('crypto');
+
+const GA_COLLECT_URL = 'https://www.google-analytics.com/mp/collect';
+const DEFAULT_EVENT_PARAMS = {
+    event_source: 'adapter',
+    engagement_time_msec: 1
+};
+const GA_CLIENT_ID = crypto.randomBytes(18).toString('hex');
+const GA_SESSION_ID = Date.now();
+
+function getMessageType({ recordingLink, faxDocLink }) {
+    if (recordingLink) return 'voicemail';
+    if (faxDocLink) return 'fax';
+    return 'sms';
+}
+
+function getCompanyKey(companyIdentifier) {
+    if (!companyIdentifier) return undefined;
+
+    const hashKey = process.env.GA_COMPANY_HASH_KEY || process.env.HASH_KEY;
+    if (hashKey) {
+        return crypto
+            .createHmac('sha256', hashKey)
+            .update(companyIdentifier)
+            .digest('hex')
+            .slice(0, 32);
+    }
+
+    return crypto
+        .createHash('sha256')
+        .update(companyIdentifier)
+        .digest('hex')
+        .slice(0, 32);
+}
+
+function getPositiveNumber(value) {
+    const numberValue = Number(value);
+    return Number.isFinite(numberValue) && numberValue >= 0 ? numberValue : undefined;
+}
+
+function getParams(params) {
+    return Object.fromEntries(
+        Object.entries(params)
+            .filter(([, value]) => value !== undefined && value !== null && value !== '')
+            .map(([key, value]) => [
+                key,
+                typeof value === 'string' ? value.slice(0, 100) : value
+            ])
+    );
+}
+
+async function track({ eventName, adapterName, companyIdentifier, params = {} }) {
+    if (!process.env.GA_MEASUREMENT_ID || !process.env.GA_API_SECRET) {
+        if (process.env.GA_ANALYTICS_LOG === 'true') {
+            console.log('[AdapterAnalytics][skipped]', {
+                eventName,
+                adapterName,
+                reason: 'missing GA_MEASUREMENT_ID or GA_API_SECRET'
+            });
+        }
+        return;
+    }
+
+    try {
+        if (process.env.GA_ANALYTICS_LOG === 'true') {
+            console.log('[AdapterAnalytics][sending]', {
+                eventName,
+                adapterName,
+                params
+            });
+        }
+
+        await axios.post(
+            GA_COLLECT_URL,
+            {
+                client_id: GA_CLIENT_ID,
+                events: [{
+                    name: eventName,
+                    params: getParams({
+                        ...DEFAULT_EVENT_PARAMS,
+                        session_id: GA_SESSION_ID,
+                        ...(process.env.GA_DEBUG_MODE === 'true' && { debug_mode: true }),
+                        adapter_name: adapterName,
+                        company_key: getCompanyKey(companyIdentifier),
+                        ...params
+                    })
+                }]
+            },
+            {
+                params: {
+                    measurement_id: process.env.GA_MEASUREMENT_ID,
+                    api_secret: process.env.GA_API_SECRET
+                },
+                timeout: 3000
+            }
+        );
+
+        if (process.env.GA_ANALYTICS_LOG === 'true') {
+            console.log('[AdapterAnalytics][sent]', {
+                eventName,
+                adapterName
+            });
+        }
+    } catch (error) {
+        console.warn('[AdapterAnalytics][gaTrackFailed]', {
+            eventName,
+            adapterName,
+            status: error?.response?.status || null,
+            message: error?.message || ''
+        });
+    }
+}
+
+function trackUserConnected({ adapterName, companyIdentifier }) {
+    return track({
+        eventName: 'crm_user_connected',
+        adapterName,
+        companyIdentifier
+    });
+}
+
+function trackContactCreated({ adapterName, companyIdentifier }) {
+    return track({
+        eventName: 'crm_contact_created',
+        adapterName,
+        companyIdentifier
+    });
+}
+
+function trackCallLogCreated({ adapterName, companyIdentifier, callDirection, callDurationSeconds }) {
+    return track({
+        eventName: 'crm_call_log_created',
+        adapterName,
+        companyIdentifier,
+        params: {
+            call_direction: callDirection,
+            call_duration_seconds: getPositiveNumber(callDurationSeconds)
+        }
+    });
+}
+
+function trackCallLogUpdated({ adapterName, companyIdentifier }) {
+    return track({
+        eventName: 'crm_call_log_updated',
+        adapterName,
+        companyIdentifier
+    });
+}
+
+function trackMessageLogCreated({ adapterName, companyIdentifier, recordingLink, faxDocLink }) {
+    return track({
+        eventName: 'crm_message_log_created',
+        adapterName,
+        companyIdentifier,
+        params: {
+            message_type: getMessageType({ recordingLink, faxDocLink })
+        }
+    });
+}
+
+function trackMessageLogUpdated({ adapterName, companyIdentifier, recordingLink, faxDocLink }) {
+    return track({
+        eventName: 'crm_message_log_updated',
+        adapterName,
+        companyIdentifier,
+        params: {
+            message_type: getMessageType({ recordingLink, faxDocLink })
+        }
+    });
+}
+
+module.exports = {
+    trackUserConnected,
+    trackContactCreated,
+    trackCallLogCreated,
+    trackCallLogUpdated,
+    trackMessageLogCreated,
+    trackMessageLogUpdated
+};

--- a/src/adapters/servicenow-core/analytics.js
+++ b/src/adapters/servicenow-core/analytics.js
@@ -1,5 +1,8 @@
 const axios = require('axios');
 const crypto = require('crypto');
+const { sequelize } = require('../servicenow-models/sequelize');
+const { initModels } = require('../servicenow-models/init-models');
+const models = initModels(sequelize);
 
 const GA_COLLECT_URL = 'https://www.google-analytics.com/mp/collect';
 const DEFAULT_EVENT_PARAMS = {
@@ -15,23 +18,21 @@ function getMessageType({ recordingLink, faxDocLink }) {
     return 'sms';
 }
 
-function getCompanyKey(companyIdentifier) {
+async function getCompanyName(companyIdentifier) {
     if (!companyIdentifier) return undefined;
 
-    const hashKey = process.env.GA_COMPANY_HASH_KEY || process.env.HASH_KEY;
-    if (hashKey) {
-        return crypto
-            .createHmac('sha256', hashKey)
-            .update(companyIdentifier)
-            .digest('hex')
-            .slice(0, 32);
+    try {
+        const company = await models.companies.findOne({
+            where: { hostname: companyIdentifier },
+            raw: true
+        });
+        return company?.companyName;
+    } catch (error) {
+        console.warn('[AdapterAnalytics][companyNameLookupFailed]', {
+            message: error?.message || ''
+        });
+        return undefined;
     }
-
-    return crypto
-        .createHash('sha256')
-        .update(companyIdentifier)
-        .digest('hex')
-        .slice(0, 32);
 }
 
 function getPositiveNumber(value) {
@@ -63,10 +64,13 @@ async function track({ eventName, adapterName, companyIdentifier, params = {} })
     }
 
     try {
+        const companyName = await getCompanyName(companyIdentifier);
+
         if (process.env.GA_ANALYTICS_LOG === 'true') {
             console.log('[AdapterAnalytics][sending]', {
                 eventName,
                 adapterName,
+                companyName,
                 params
             });
         }
@@ -82,7 +86,7 @@ async function track({ eventName, adapterName, companyIdentifier, params = {} })
                         session_id: GA_SESSION_ID,
                         ...(process.env.GA_DEBUG_MODE === 'true' && { debug_mode: true }),
                         adapter_name: adapterName,
-                        company_key: getCompanyKey(companyIdentifier),
+                        company_name: companyName,
                         ...params
                     })
                 }]

--- a/src/adapters/servicenow/index.js
+++ b/src/adapters/servicenow/index.js
@@ -17,6 +17,7 @@ const FormData = require("form-data");
 const s3Helper = require('../servicenow-core/s3');
 const AWS = require('aws-sdk');
 const crypto = require('crypto');
+const analytics = require('../servicenow-core/analytics');
 const serviceNowApiClient = axios.create();
 
 function stringifyForLog(value, maxLength = 1200) {
@@ -289,6 +290,10 @@ async function getUserInfo({ authHeader, additionalInfo, hostname}) {
                 //if the max numbers of users is greater than the active customers we allow to insert new customer
 
                 if (userData.name == 'admin' && checkActiveUsers.customers.some(customer => customer.email === email)) {
+                    await analytics.trackUserConnected({
+                        adapterName: 'servicenow',
+                        companyIdentifier: hostname
+                    });
                     return {
                         successful: true,
                         platformUserInfo: {
@@ -309,6 +314,10 @@ async function getUserInfo({ authHeader, additionalInfo, hostname}) {
                 if (checkActiveUsers.customers.length < checkActiveUsers.maxAllowedUsers) {
 
                     if (checkActiveUsers.customers.some(customer => customer.sysId === id)) {
+                        await analytics.trackUserConnected({
+                            adapterName: 'servicenow',
+                            companyIdentifier: hostname
+                        });
                         return {
                             successful: true,
                             platformUserInfo: {
@@ -329,6 +338,10 @@ async function getUserInfo({ authHeader, additionalInfo, hostname}) {
                         const accessToken = authHeader.split(' ')[1];
                         //Save the auth token and new user information in the MYSQL customers table
                         await saveUserInfo(userData, accessToken, checkActiveUsers.dataValues.hostname, checkActiveUsers.dataValues.id);
+                        await analytics.trackUserConnected({
+                            adapterName: 'servicenow',
+                            companyIdentifier: hostname
+                        });
                         return {
                             successful: true,
                             platformUserInfo: {
@@ -790,6 +803,13 @@ async function createCallLog({ user, contactInfo, authHeader, callLog, note, add
         await uploadToServiceNow(s3Url, hostname, authHeader, addLogRes?.data?.result?.sys_id, fileName);
     }
 
+    await analytics.trackCallLogCreated({
+        adapterName: 'servicenow',
+        companyIdentifier: user.hostname || user.dataValues?.hostname,
+        callDirection: callLog.direction,
+        callDurationSeconds: callLog.duration
+    });
+
     //----------------------------------------------------------------------------
     //---CHECK.4: Open db.sqlite and CRM website to check if call log is saved ---
     //----------------------------------------------------------------------------
@@ -992,6 +1012,11 @@ async function updateCallLog({ user, existingCallLog, authHeader, recordingLink,
         await uploadToServiceNow(s3Url, hostname, authHeader, existingLogId, fileName)
     }
 
+    await analytics.trackCallLogUpdated({
+        adapterName: 'servicenow',
+        companyIdentifier: user.hostname || user.dataValues?.hostname
+    });
+
     const patchLogRes = {
         data: {
             id: patchLog.data.result.sys_id
@@ -1120,6 +1145,13 @@ async function createMessageLog({ user, contactInfo, authHeader, message, additi
         );
     }
 
+    await analytics.trackMessageLogCreated({
+        adapterName: 'servicenow',
+        companyIdentifier: user.hostname || user.dataValues?.hostname,
+        recordingLink,
+        faxDocLink
+    });
+
     //-------------------------------------------------------------------------------------------------------------
     //---CHECK.7: For single message logging, open db.sqlite and CRM website to check if message logs are saved ---
     //-------------------------------------------------------------------------------------------------------------
@@ -1227,6 +1259,13 @@ async function updateMessageLog({ user, contactInfo, existingMessageLog, message
         );
     }
 
+    await analytics.trackMessageLogUpdated({
+        adapterName: 'servicenow',
+        companyIdentifier: user.hostname || user.dataValues?.hostname,
+        recordingLink,
+        faxDocLink
+    });
+
     //---------------------------------------------------------------------------------------------------------------------------------------------
     //---CHECK.8: For multiple messages or additional message during the day, open db.sqlite and CRM website to check if message logs are saved ---
     //---------------------------------------------------------------------------------------------------------------------------------------------
@@ -1300,6 +1339,11 @@ async function createContact({ user, authHeader, phoneNumber, newContactName, ne
             }
         );
     }
+
+    await analytics.trackContactCreated({
+        adapterName: 'servicenow',
+        companyIdentifier: user.hostname || user.dataValues?.hostname
+    });
 
     //--------------------------------------------------------------------------------
     //---CHECK.9: In extension, try create a new contact against an unknown number ---

--- a/src/adapters/servicenow/index.js
+++ b/src/adapters/servicenow/index.js
@@ -20,6 +20,8 @@ const crypto = require('crypto');
 const analytics = require('../servicenow-core/analytics');
 const serviceNowApiClient = axios.create();
 
+const ADAPTER_NAME = 'servicenow';
+
 function stringifyForLog(value, maxLength = 1200) {
     try {
         const str = typeof value === 'string' ? value : JSON.stringify(value);
@@ -291,7 +293,7 @@ async function getUserInfo({ authHeader, additionalInfo, hostname}) {
 
                 if (userData.name == 'admin' && checkActiveUsers.customers.some(customer => customer.email === email)) {
                     await analytics.trackUserConnected({
-                        adapterName: 'servicenow',
+                        adapterName: ADAPTER_NAME,
                         companyIdentifier: hostname
                     });
                     return {
@@ -315,7 +317,7 @@ async function getUserInfo({ authHeader, additionalInfo, hostname}) {
 
                     if (checkActiveUsers.customers.some(customer => customer.sysId === id)) {
                         await analytics.trackUserConnected({
-                            adapterName: 'servicenow',
+                            adapterName: ADAPTER_NAME,
                             companyIdentifier: hostname
                         });
                         return {
@@ -339,7 +341,7 @@ async function getUserInfo({ authHeader, additionalInfo, hostname}) {
                         //Save the auth token and new user information in the MYSQL customers table
                         await saveUserInfo(userData, accessToken, checkActiveUsers.dataValues.hostname, checkActiveUsers.dataValues.id);
                         await analytics.trackUserConnected({
-                            adapterName: 'servicenow',
+                            adapterName: ADAPTER_NAME,
                             companyIdentifier: hostname
                         });
                         return {
@@ -804,7 +806,7 @@ async function createCallLog({ user, contactInfo, authHeader, callLog, note, add
     }
 
     await analytics.trackCallLogCreated({
-        adapterName: 'servicenow',
+        adapterName: ADAPTER_NAME,
         companyIdentifier: user.hostname || user.dataValues?.hostname,
         callDirection: callLog.direction,
         callDurationSeconds: callLog.duration
@@ -1013,7 +1015,7 @@ async function updateCallLog({ user, existingCallLog, authHeader, recordingLink,
     }
 
     await analytics.trackCallLogUpdated({
-        adapterName: 'servicenow',
+        adapterName: ADAPTER_NAME,
         companyIdentifier: user.hostname || user.dataValues?.hostname
     });
 
@@ -1146,7 +1148,7 @@ async function createMessageLog({ user, contactInfo, authHeader, message, additi
     }
 
     await analytics.trackMessageLogCreated({
-        adapterName: 'servicenow',
+        adapterName: ADAPTER_NAME,
         companyIdentifier: user.hostname || user.dataValues?.hostname,
         recordingLink,
         faxDocLink
@@ -1260,7 +1262,7 @@ async function updateMessageLog({ user, contactInfo, existingMessageLog, message
     }
 
     await analytics.trackMessageLogUpdated({
-        adapterName: 'servicenow',
+        adapterName: ADAPTER_NAME,
         companyIdentifier: user.hostname || user.dataValues?.hostname,
         recordingLink,
         faxDocLink
@@ -1341,7 +1343,7 @@ async function createContact({ user, authHeader, phoneNumber, newContactName, ne
     }
 
     await analytics.trackContactCreated({
-        adapterName: 'servicenow',
+        adapterName: ADAPTER_NAME,
         companyIdentifier: user.hostname || user.dataValues?.hostname
     });
 

--- a/src/adapters/servicenow/manifest.json
+++ b/src/adapters/servicenow/manifest.json
@@ -1,5 +1,5 @@
 {
-    "serverUrl": "https://rcservicenowapi.gate6.com",
+    "serverUrl": "https://rc-crmapi.test.gate6.com",
     "redirectUri": "https://ringcentral.github.io/ringcentral-embeddable/redirect.html",
     "author": {
         "name": "Gate6",
@@ -71,25 +71,25 @@
                         {
                             "id": "serviceNowInboundCallState",
                             "type": "inputField",
-                            "name": "Default action for inbound calls",
+                            "name": "Default value for inbound calls",
                             "placeholder": "Enter action value"
                         },
                         {
                             "id": "serviceNowOutboundCallState",
                             "type": "inputField",
-                            "name": "Default action for outbound calls",
+                            "name": "Default value for outbound calls",
                             "placeholder": "Enter action value"
                         },
                         {
                             "id": "serviceNowMessageState",
                             "type": "inputField",
-                            "name": "Default action for SMS",
+                            "name": "Default value for SMS",
                             "placeholder": "Enter action value"
                         },
                         {
                             "id": "serviceNowVoicemailState",
                             "type": "inputField",
-                            "name": "Default action for voicemails",
+                            "name": "Default value for voicemails",
                             "placeholder": "Enter action value"
                         }
                     ]
@@ -108,25 +108,25 @@
                         {
                             "id": "serviceNowInboundCallType",
                             "type": "inputField",
-                            "name": "Default action for inbound calls",
+                            "name": "Default value for inbound calls",
                             "placeholder": "Enter action value"
                         },
                         {
                             "id": "serviceNowOutboundCallType",
                             "type": "inputField",
-                            "name": "Default action for outbound calls",
+                            "name": "Default value for outbound calls",
                             "placeholder": "Enter action value"
                         },
                         {
                             "id": "serviceNowMessageType",
                             "type": "inputField",
-                            "name": "Default action for SMS",
+                            "name": "Default value for SMS",
                             "placeholder": "Enter action value"
                         },
                         {
                             "id": "serviceNowVoicemailType",
                             "type": "inputField",
-                            "name": "Default action for voicemails",
+                            "name": "Default value for voicemails",
                             "placeholder": "Enter action value"
                         }
                     ]
@@ -275,5 +275,5 @@
                 }}
             }
     },
-    "version": "1.5.6"
+    "version": "1.6.21"
 }

--- a/src/adapters/servicetitan/index.js
+++ b/src/adapters/servicetitan/index.js
@@ -13,6 +13,7 @@ const { initModels } = require('../servicenow-models/init-models');
 const models = initModels(sequelize);
 const analytics = require('../servicenow-core/analytics');
 
+const ADAPTER_NAME = 'servicetitan';
 const SERVICE_TITAN_JPM_URL= "https://api-integration.servicetitan.io/jpm/v2/tenant"
 const SERVICE_TITAN_CRM_URL= "https://api-integration.servicetitan.io/crm/v2/tenant"
 
@@ -193,7 +194,7 @@ async function getUserInfo(authHeader) {
         }
 
         await analytics.trackUserConnected({
-            adapterName: 'servicetitan',
+            adapterName: ADAPTER_NAME,
             companyIdentifier: hostname
         });
 
@@ -426,7 +427,7 @@ async function createContact({ user, phoneNumber, newContactName }) {
         const createdContact = response.data;
 
         await analytics.trackContactCreated({
-            adapterName: 'servicetitan',
+            adapterName: ADAPTER_NAME,
             companyIdentifier: user.hostname || user.dataValues?.hostname
         });
 
@@ -600,7 +601,7 @@ async function createCallLog({ user, contactInfo, callLog, note, aiNote, transcr
     }
 
     await analytics.trackCallLogCreated({
-        adapterName: 'servicetitan',
+        adapterName: ADAPTER_NAME,
         companyIdentifier: user.hostname || user.dataValues?.hostname,
         callDirection: callLog.direction,
         callDurationSeconds: callLog.duration
@@ -782,7 +783,7 @@ async function updateCallLog({ user, existingCallLog, recordingLink, note, aiNot
     }
 
     await analytics.trackCallLogUpdated({
-        adapterName: 'servicetitan',
+        adapterName: ADAPTER_NAME,
         companyIdentifier: user.hostname || user.dataValues?.hostname
     });
 
@@ -867,7 +868,7 @@ ${faxDocLink}
     );
 
     await analytics.trackMessageLogCreated({
-        adapterName: 'servicetitan',
+        adapterName: ADAPTER_NAME,
         companyIdentifier: user.hostname || user.dataValues?.hostname,
         recordingLink,
         faxDocLink
@@ -1007,7 +1008,7 @@ ${faxDocLink}
     }
 
     await analytics.trackMessageLogUpdated({
-        adapterName: 'servicetitan',
+        adapterName: ADAPTER_NAME,
         companyIdentifier: user.hostname || user.dataValues?.hostname,
         recordingLink,
         faxDocLink

--- a/src/adapters/servicetitan/index.js
+++ b/src/adapters/servicetitan/index.js
@@ -11,6 +11,7 @@ const qs = require('qs');
 const { sequelize } = require('../servicenow-models/sequelize');
 const { initModels } = require('../servicenow-models/init-models');
 const models = initModels(sequelize);
+const analytics = require('../servicenow-core/analytics');
 
 const SERVICE_TITAN_JPM_URL= "https://api-integration.servicetitan.io/jpm/v2/tenant"
 const SERVICE_TITAN_CRM_URL= "https://api-integration.servicetitan.io/crm/v2/tenant"
@@ -190,6 +191,11 @@ async function getUserInfo(authHeader) {
                 updatedAt: new Date()
             });
         }
+
+        await analytics.trackUserConnected({
+            adapterName: 'servicetitan',
+            companyIdentifier: hostname
+        });
 
         return {
             successful: true,
@@ -419,6 +425,11 @@ async function createContact({ user, phoneNumber, newContactName }) {
 
         const createdContact = response.data;
 
+        await analytics.trackContactCreated({
+            adapterName: 'servicetitan',
+            companyIdentifier: user.hostname || user.dataValues?.hostname
+        });
+
         return {
             contactInfo: {
                 id: createdContact.id,
@@ -587,6 +598,13 @@ async function createCallLog({ user, contactInfo, callLog, note, aiNote, transcr
 
         logType = "job";
     }
+
+    await analytics.trackCallLogCreated({
+        adapterName: 'servicetitan',
+        companyIdentifier: user.hostname || user.dataValues?.hostname,
+        callDirection: callLog.direction,
+        callDurationSeconds: callLog.duration
+    });
 
     return {
         logId: `${addNoteRes.data.id}_${logType}`,
@@ -763,6 +781,11 @@ async function updateCallLog({ user, existingCallLog, recordingLink, note, aiNot
         await logID_db.save();
     }
 
+    await analytics.trackCallLogUpdated({
+        adapterName: 'servicetitan',
+        companyIdentifier: user.hostname || user.dataValues?.hostname
+    });
+
     return {
         logId: newLogId,
         returnMessage: {
@@ -842,6 +865,13 @@ ${faxDocLink}
             }
         }
     );
+
+    await analytics.trackMessageLogCreated({
+        adapterName: 'servicetitan',
+        companyIdentifier: user.hostname || user.dataValues?.hostname,
+        recordingLink,
+        faxDocLink
+    });
 
     return {
         logId: addLogRes.data.id,
@@ -975,6 +1005,13 @@ ${faxDocLink}
         messageLogID_db.thirdPartyLogId = addLogRes.data.id;
         await messageLogID_db.save();
     }
+
+    await analytics.trackMessageLogUpdated({
+        adapterName: 'servicetitan',
+        companyIdentifier: user.hostname || user.dataValues?.hostname,
+        recordingLink,
+        faxDocLink
+    });
 
     return {
         logId: addLogRes.data.id,


### PR DESCRIPTION
1. Added a shared Google Analytics helper under servicenow-core for adapter-side GA Measurement Protocol tracking.

2. Integrated successful operation tracking across ServiceNow, ServiceTitan, Monday, and AgencyZoom adapters.

3. Added events for user connection, contact creation, call log create/update, and message log create/update, including safe metadata like adapter name, company key, call direction, duration, and message type.

4. Added debug/log support via env flags while avoiding sensitive data such as phone numbers, emails, notes, transcripts, tokens, and raw CRM payloads.