### PR TITLE
added event analytics using GA

### DIFF
--- a/src/adapters/agencyzoom/index.js
+++ b/src/adapters/agencyzoom/index.js
@@ -8,8 +8,10 @@ const { UserModel } = require('@app-connect/core/models/userModel');
 const { CallLogModel } = require('@app-connect/core/models/callLogModel');
 const { sequelize } = require('../servicenow-models/sequelize');
 const { initModels } = require('../servicenow-models/init-models');
+const analytics = require('../servicenow-core/analytics');
 const models = initModels(sequelize);
 
+const ADAPTER_NAME = 'agencyzoom';
 const AZ_BASE_URL = "https://api.agencyzoom.com/v1/api";
 
 async function getLicenseStatus({ userId }) {
@@ -251,6 +253,11 @@ async function getUserInfo(authHeader) {
       });
     }
 
+    await analytics.trackUserConnected({
+      adapterName: ADAPTER_NAME,
+      companyIdentifier: hostname
+    });
+
     // Success response
     return {
       successful: true,
@@ -468,6 +475,11 @@ async function createContact({ user, phoneNumber, newContactName }) {
     }
   );
 
+  await analytics.trackContactCreated({
+    adapterName: ADAPTER_NAME,
+    companyIdentifier: user.hostname || user.dataValues?.hostname
+  });
+
   return {
     contactInfo: {
       id: res.data.id,
@@ -526,6 +538,13 @@ ${description}
     { note: noteBody },
     { headers: { Authorization: `Bearer ${auth}` } }
   );
+
+  await analytics.trackCallLogCreated({
+    adapterName: ADAPTER_NAME,
+    companyIdentifier: user.hostname || user.dataValues?.hostname,
+    callDirection: callLog.direction,
+    callDurationSeconds: callLog.duration
+  });
 
   return {
     logId,
@@ -632,6 +651,11 @@ ${description}
     { note: noteBody },
     { headers: { Authorization: `Bearer ${auth}` } }
   );
+
+  await analytics.trackCallLogUpdated({
+    adapterName: ADAPTER_NAME,
+    companyIdentifier: user.hostname || user.dataValues?.hostname
+  });
 
   return {
     logId,
@@ -798,6 +822,13 @@ ${description}
     { headers: { Authorization: `Bearer ${auth}` } }
   );
 
+  await analytics.trackMessageLogCreated({
+    adapterName: ADAPTER_NAME,
+    companyIdentifier: user.hostname || user.dataValues?.hostname,
+    recordingLink,
+    faxDocLink
+  });
+
   return {
     logId,
     contactId: Number(contactInfo.id),
@@ -902,6 +933,13 @@ ${updatedConversation}
     { note: noteBody },
     { headers: { Authorization: `Bearer ${auth}` } }
   );
+
+  await analytics.trackMessageLogUpdated({
+    adapterName: ADAPTER_NAME,
+    companyIdentifier: user.hostname || user.dataValues?.hostname,
+    recordingLink,
+    faxDocLink
+  });
 
   return {
     logId,

--- a/src/adapters/monday/index.js
+++ b/src/adapters/monday/index.js
@@ -8,7 +8,9 @@ const models = initModels(sequelize);
 const FormData = require('form-data')
 const s3Helper = require('../servicenow-core/s3');
 const AWS = require('aws-sdk');
+const analytics = require('../servicenow-core/analytics');
 
+const ADAPTER_NAME = 'monday';
 const MONDAY_API_URL = process.env.MONDAY_API_URL;
 const MONDAY_AUTHORIZE_URL = process.env.MONDAY_AUTHORIZE_URL;
 var MONDAY_CLIENT_SECRET = '';
@@ -421,6 +423,11 @@ async function getUserInfo({ authHeader, hostname, query }) {
       });
     }
 
+    await analytics.trackUserConnected({
+      adapterName: ADAPTER_NAME,
+      companyIdentifier: hostname
+    });
+
     return {
       successful: true,
       platformUserInfo: {
@@ -645,6 +652,11 @@ async function createContact({ phoneNumber, newContactName, accessToken, authHea
     }
   )
 
+  await analytics.trackContactCreated({
+    adapterName: ADAPTER_NAME,
+    companyIdentifier: user.hostname || user.dataValues?.hostname
+  })
+
   return {
     contactInfo: {
       id: res.data.create_item.id,
@@ -742,6 +754,13 @@ async function createCallLog({ contactInfo, callLog, note, aiNote, transcript, a
     })
   }
 
+  await analytics.trackCallLogCreated({
+    adapterName: ADAPTER_NAME,
+    companyIdentifier: user.hostname || user.dataValues?.hostname,
+    callDirection: callLog.direction,
+    callDurationSeconds: callLog.duration
+  })
+
   return {
     logId: updateId,
     contactId: Number(contactInfo.id),
@@ -827,6 +846,11 @@ async function updateCallLog({ existingCallLog, recordingLink, note, aiNote, tra
       body
     }
   )
+
+  await analytics.trackCallLogUpdated({
+    adapterName: ADAPTER_NAME,
+    companyIdentifier: user.hostname || user.dataValues?.hostname
+  })
 
   return {
     logId: updateRes.data.edit_update.id,
@@ -1005,6 +1029,13 @@ async function createMessageLog({ user, contactInfo, message, recordingLink, fax
       hostname: user.dataValues.hostname
     })
   }
+
+  await analytics.trackMessageLogCreated({
+    adapterName: ADAPTER_NAME,
+    companyIdentifier: user.hostname || user.dataValues?.hostname,
+    recordingLink,
+    faxDocLink
+  })
 
   return {
     logId: updateId,
@@ -1208,6 +1239,13 @@ async function updateMessageLog({ user, contactInfo, existingMessageLog, message
       hostname: user.dataValues.hostname
     })
   }
+
+  await analytics.trackMessageLogUpdated({
+    adapterName: ADAPTER_NAME,
+    companyIdentifier: user.hostname || user.dataValues?.hostname,
+    recordingLink,
+    faxDocLink
+  })
 
   return {
     logId: newThreadId,

--- a/src/adapters/servicenow-core/analytics.js
+++ b/src/adapters/servicenow-core/analytics.js
@@ -1,0 +1,184 @@
+const axios = require('axios');
+const crypto = require('crypto');
+const { sequelize } = require('../servicenow-models/sequelize');
+const { initModels } = require('../servicenow-models/init-models');
+const models = initModels(sequelize);
+
+const GA_COLLECT_URL = 'https://www.google-analytics.com/mp/collect';
+const DEFAULT_EVENT_PARAMS = {
+    event_source: 'adapter',
+    engagement_time_msec: 1
+};
+const GA_CLIENT_ID = crypto.randomBytes(18).toString('hex');
+const GA_SESSION_ID = Date.now();
+
+function getMessageType({ recordingLink, faxDocLink }) {
+    if (recordingLink) return 'voicemail';
+    if (faxDocLink) return 'fax';
+    return 'sms';
+}
+
+async function getCompanyName(companyIdentifier) {
+    if (!companyIdentifier) return undefined;
+
+    try {
+        const company = await models.companies.findOne({
+            where: { hostname: companyIdentifier },
+            raw: true
+        });
+        return company?.companyName;
+    } catch (error) {
+        console.warn('[AdapterAnalytics][companyNameLookupFailed]', {
+            message: error?.message || ''
+        });
+        return undefined;
+    }
+}
+
+function getPositiveNumber(value) {
+    const numberValue = Number(value);
+    return Number.isFinite(numberValue) && numberValue >= 0 ? numberValue : undefined;
+}
+
+function getParams(params) {
+    return Object.fromEntries(
+        Object.entries(params)
+            .filter(([, value]) => value !== undefined && value !== null && value !== '')
+            .map(([key, value]) => [
+                key,
+                typeof value === 'string' ? value.slice(0, 100) : value
+            ])
+    );
+}
+
+async function track({ eventName, adapterName, companyIdentifier, params = {} }) {
+    if (!process.env.GA_MEASUREMENT_ID || !process.env.GA_API_SECRET) {
+        if (process.env.GA_ANALYTICS_LOG === 'true') {
+            console.log('[AdapterAnalytics][skipped]', {
+                eventName,
+                adapterName,
+                reason: 'missing GA_MEASUREMENT_ID or GA_API_SECRET'
+            });
+        }
+        return;
+    }
+
+    try {
+        const companyName = await getCompanyName(companyIdentifier);
+
+        if (process.env.GA_ANALYTICS_LOG === 'true') {
+            console.log('[AdapterAnalytics][sending]', {
+                eventName,
+                adapterName,
+                companyName,
+                params
+            });
+        }
+
+        await axios.post(
+            GA_COLLECT_URL,
+            {
+                client_id: GA_CLIENT_ID,
+                events: [{
+                    name: eventName,
+                    params: getParams({
+                        ...DEFAULT_EVENT_PARAMS,
+                        session_id: GA_SESSION_ID,
+                        ...(process.env.GA_DEBUG_MODE === 'true' && { debug_mode: true }),
+                        adapter_name: adapterName,
+                        company_name: companyName,
+                        ...params
+                    })
+                }]
+            },
+            {
+                params: {
+                    measurement_id: process.env.GA_MEASUREMENT_ID,
+                    api_secret: process.env.GA_API_SECRET
+                },
+                timeout: 3000
+            }
+        );
+
+        if (process.env.GA_ANALYTICS_LOG === 'true') {
+            console.log('[AdapterAnalytics][sent]', {
+                eventName,
+                adapterName
+            });
+        }
+    } catch (error) {
+        console.warn('[AdapterAnalytics][gaTrackFailed]', {
+            eventName,
+            adapterName,
+            status: error?.response?.status || null,
+            message: error?.message || ''
+        });
+    }
+}
+
+function trackUserConnected({ adapterName, companyIdentifier }) {
+    return track({
+        eventName: 'crm_user_connected',
+        adapterName,
+        companyIdentifier
+    });
+}
+
+function trackContactCreated({ adapterName, companyIdentifier }) {
+    return track({
+        eventName: 'crm_contact_created',
+        adapterName,
+        companyIdentifier
+    });
+}
+
+function trackCallLogCreated({ adapterName, companyIdentifier, callDirection, callDurationSeconds }) {
+    return track({
+        eventName: 'crm_call_log_created',
+        adapterName,
+        companyIdentifier,
+        params: {
+            call_direction: callDirection,
+            call_duration_seconds: getPositiveNumber(callDurationSeconds)
+        }
+    });
+}
+
+function trackCallLogUpdated({ adapterName, companyIdentifier }) {
+    return track({
+        eventName: 'crm_call_log_updated',
+        adapterName,
+        companyIdentifier
+    });
+}
+
+function trackMessageLogCreated({ adapterName, companyIdentifier, recordingLink, faxDocLink }) {
+    return track({
+        eventName: 'crm_message_log_created',
+        adapterName,
+        companyIdentifier,
+        params: {
+            message_type: getMessageType({ recordingLink, faxDocLink })
+        }
+    });
+}
+
+function trackMessageLogUpdated({ adapterName, companyIdentifier, recordingLink, faxDocLink }) {
+    return track({
+        eventName: 'crm_message_log_updated',
+        adapterName,
+        companyIdentifier,
+        params: {
+            message_type: getMessageType({ recordingLink, faxDocLink })
+        }
+    });
+}
+
+module.exports = {
+    trackUserConnected,
+    trackContactCreated,
+    trackCallLogCreated,
+    trackCallLogUpdated,
+    trackMessageLogCreated,
+    trackMessageLogUpdated
+};

--- a/src/adapters/servicenow/index.js
+++ b/src/adapters/servicenow/index.js
@@ -17,7 +17,10 @@ const FormData = require("form-data");
 const s3Helper = require('../servicenow-core/s3');
 const AWS = require('aws-sdk');
 const crypto = require('crypto');
+const analytics = require('../servicenow-core/analytics');
 const serviceNowApiClient = axios.create();
+
+const ADAPTER_NAME = 'servicenow';
 
 function stringifyForLog(value, maxLength = 1200) {
     try {
@@ -289,6 +292,10 @@ async function getUserInfo({ authHeader, additionalInfo, hostname}) {
                 //if the max numbers of users is greater than the active customers we allow to insert new customer
 
                 if (userData.name == 'admin' && checkActiveUsers.customers.some(customer => customer.email === email)) {
+                    await analytics.trackUserConnected({
+                        adapterName: ADAPTER_NAME,
+                        companyIdentifier: hostname
+                    });
                     return {
                         successful: true,
                         platformUserInfo: {
@@ -309,6 +316,10 @@ async function getUserInfo({ authHeader, additionalInfo, hostname}) {
                 if (checkActiveUsers.customers.length < checkActiveUsers.maxAllowedUsers) {
 
                     if (checkActiveUsers.customers.some(customer => customer.sysId === id)) {
+                        await analytics.trackUserConnected({
+                            adapterName: ADAPTER_NAME,
+                            companyIdentifier: hostname
+                        });
                         return {
                             successful: true,
                             platformUserInfo: {
@@ -329,6 +340,10 @@ async function getUserInfo({ authHeader, additionalInfo, hostname}) {
                         const accessToken = authHeader.split(' ')[1];
                         //Save the auth token and new user information in the MYSQL customers table
                         await saveUserInfo(userData, accessToken, checkActiveUsers.dataValues.hostname, checkActiveUsers.dataValues.id);
+                        await analytics.trackUserConnected({
+                            adapterName: ADAPTER_NAME,
+                            companyIdentifier: hostname
+                        });
                         return {
                             successful: true,
                             platformUserInfo: {
@@ -790,6 +805,13 @@ async function createCallLog({ user, contactInfo, authHeader, callLog, note, add
         await uploadToServiceNow(s3Url, hostname, authHeader, addLogRes?.data?.result?.sys_id, fileName);
     }
 
+    await analytics.trackCallLogCreated({
+        adapterName: ADAPTER_NAME,
+        companyIdentifier: user.hostname || user.dataValues?.hostname,
+        callDirection: callLog.direction,
+        callDurationSeconds: callLog.duration
+    });
+
     //----------------------------------------------------------------------------
     //---CHECK.4: Open db.sqlite and CRM website to check if call log is saved ---
     //----------------------------------------------------------------------------
@@ -992,6 +1014,11 @@ async function updateCallLog({ user, existingCallLog, authHeader, recordingLink,
         await uploadToServiceNow(s3Url, hostname, authHeader, existingLogId, fileName)
     }
 
+    await analytics.trackCallLogUpdated({
+        adapterName: ADAPTER_NAME,
+        companyIdentifier: user.hostname || user.dataValues?.hostname
+    });
+
     const patchLogRes = {
         data: {
             id: patchLog.data.result.sys_id
@@ -1120,6 +1147,13 @@ async function createMessageLog({ user, contactInfo, authHeader, message, additi
         );
     }
 
+    await analytics.trackMessageLogCreated({
+        adapterName: ADAPTER_NAME,
+        companyIdentifier: user.hostname || user.dataValues?.hostname,
+        recordingLink,
+        faxDocLink
+    });
+
     //-------------------------------------------------------------------------------------------------------------
     //---CHECK.7: For single message logging, open db.sqlite and CRM website to check if message logs are saved ---
     //-------------------------------------------------------------------------------------------------------------
@@ -1227,6 +1261,13 @@ async function updateMessageLog({ user, contactInfo, existingMessageLog, message
         );
     }
 
+    await analytics.trackMessageLogUpdated({
+        adapterName: ADAPTER_NAME,
+        companyIdentifier: user.hostname || user.dataValues?.hostname,
+        recordingLink,
+        faxDocLink
+    });
+
     //---------------------------------------------------------------------------------------------------------------------------------------------
     //---CHECK.8: For multiple messages or additional message during the day, open db.sqlite and CRM website to check if message logs are saved ---
     //---------------------------------------------------------------------------------------------------------------------------------------------
@@ -1300,6 +1341,11 @@ async function createContact({ user, authHeader, phoneNumber, newContactName, ne
             }
         );
     }
+
+    await analytics.trackContactCreated({
+        adapterName: ADAPTER_NAME,
+        companyIdentifier: user.hostname || user.dataValues?.hostname
+    });
 
     //--------------------------------------------------------------------------------
     //---CHECK.9: In extension, try create a new contact against an unknown number ---

--- a/src/adapters/servicetitan/index.js
+++ b/src/adapters/servicetitan/index.js
@@ -11,7 +11,9 @@ const qs = require('qs');
 const { sequelize } = require('../servicenow-models/sequelize');
 const { initModels } = require('../servicenow-models/init-models');
 const models = initModels(sequelize);
+const analytics = require('../servicenow-core/analytics');
 
+const ADAPTER_NAME = 'servicetitan';
 const SERVICE_TITAN_JPM_URL= "https://api-integration.servicetitan.io/jpm/v2/tenant"
 const SERVICE_TITAN_CRM_URL= "https://api-integration.servicetitan.io/crm/v2/tenant"
 
@@ -190,6 +192,11 @@ async function getUserInfo(authHeader) {
                 updatedAt: new Date()
             });
         }
+
+        await analytics.trackUserConnected({
+            adapterName: ADAPTER_NAME,
+            companyIdentifier: hostname
+        });
 
         return {
             successful: true,
@@ -419,6 +426,11 @@ async function createContact({ user, phoneNumber, newContactName }) {
 
         const createdContact = response.data;
 
+        await analytics.trackContactCreated({
+            adapterName: ADAPTER_NAME,
+            companyIdentifier: user.hostname || user.dataValues?.hostname
+        });
+
         return {
             contactInfo: {
                 id: createdContact.id,
@@ -587,6 +599,13 @@ async function createCallLog({ user, contactInfo, callLog, note, aiNote, transcr
 
         logType = "job";
     }
+
+    await analytics.trackCallLogCreated({
+        adapterName: ADAPTER_NAME,
+        companyIdentifier: user.hostname || user.dataValues?.hostname,
+        callDirection: callLog.direction,
+        callDurationSeconds: callLog.duration
+    });
 
     return {
         logId: `${addNoteRes.data.id}_${logType}`,
@@ -763,6 +782,11 @@ async function updateCallLog({ user, existingCallLog, recordingLink, note, aiNot
         await logID_db.save();
     }
 
+    await analytics.trackCallLogUpdated({
+        adapterName: ADAPTER_NAME,
+        companyIdentifier: user.hostname || user.dataValues?.hostname
+    });
+
     return {
         logId: newLogId,
         returnMessage: {
@@ -842,6 +866,13 @@ ${faxDocLink}
             }
         }
     );
+
+    await analytics.trackMessageLogCreated({
+        adapterName: ADAPTER_NAME,
+        companyIdentifier: user.hostname || user.dataValues?.hostname,
+        recordingLink,
+        faxDocLink
+    });
 
     return {
         logId: addLogRes.data.id,
@@ -975,6 +1006,13 @@ ${faxDocLink}
         messageLogID_db.thirdPartyLogId = addLogRes.data.id;
         await messageLogID_db.save();
     }
+
+    await analytics.trackMessageLogUpdated({
+        adapterName: ADAPTER_NAME,
+        companyIdentifier: user.hostname || user.dataValues?.hostname,
+        recordingLink,
+        faxDocLink
+    });
 
     return {
         logId: addLogRes.data.id,


### PR DESCRIPTION
1. Added a shared Google Analytics helper under servicenow-core for adapter-side GA Measurement Protocol tracking.
 
2. Integrated successful operation tracking across ServiceNow, ServiceTitan, Monday, and AgencyZoom adapters.

3. Added events for user connection, contact creation, call log create/update, and message log create/update, including safe metadata like adapter name, company key, call direction, duration, and message type.

4. Added debug/log support via env flags while avoiding sensitive data such as phone numbers, emails, notes, transcripts, tokens, and raw CRM payloads.