### PR TITLE
fixed getLogFormat

### DIFF
--- a/src/connectors/agencyzoom/index.js
+++ b/src/connectors/agencyzoom/index.js
@@ -976,7 +976,7 @@ async function getUserList() {
 /* ---------------- LOG FORMAT ---------------- */
 
 function getLogFormatType() {
-  return "text";
+  return "text/plain";
 }
 
 /* ---------------- EXPORTS ---------------- */


### PR DESCRIPTION
Fixed `getLogFormat `to return `'text/plain'` instead of just `'text'`