### PR TITLE
Fixed monday adapter's basic flow

### DIFF
--- a/src/connectors/agencyzoom/index.ts
+++ b/src/connectors/agencyzoom/index.ts
@@ -116,9 +116,9 @@ async function getRefreshedAuthToken(user) {
 /* ---------------- USER INFO ---------------- */
 
 async function getUserInfo({ hostname, additionalInfo }) {
-  // rcAccountId arrives via the manifest's rcAdditionalSubmission (auto from RC cached
-  // data — no user prompt, no framework change).
-  const { username, password, rcAccountId, } = additionalInfo ?? {};
+  // rcAccountId, rcExtensionId, rcUserName, rcUserEmail arrive via the manifest's
+  // rcAdditionalSubmission (auto from RC cached data — no user prompt, no framework change).
+  const { username, password, rcAccountId, rcExtensionId, rcUserName, rcUserEmail } = additionalInfo ?? {};
 
   if (!hostname || !username || !password) {
     return {
@@ -128,16 +128,32 @@ async function getUserInfo({ hostname, additionalInfo }) {
     };
   }
 
-  // Tenant-scope the id so the same AgencyZoom username under different RC accounts
-  // never collides (AgencyZoom uses one fixed URL for all tenants). The username is the
-  // per-user key (no RC extension id needed here); sanitize it the same way ServiceTitan
-  // sanitizes its email key — AZ usernames are often emails, so the raw value can carry
-  // '@'/'.'/spaces and produce an unstable id.
-  if (!rcAccountId) {
-    console.warn('[AgencyZoom][getUserInfo] missing rcAccountId — falling back to non-tenant-scoped id');
-  }
-  const userKey = String(username).trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
-  const userId = rcAccountId ? `az-user-${rcAccountId}-${userKey}` : `az-user-${userKey}`;
+  // Per-user uniqueness (mirrors ServiceTitan): the extension id is preferred, but only
+  // when it's genuinely distinct from the account id — observed RC cached data can surface
+  // the same number for both (extensionInfo.id == account.id), which would collapse every
+  // user onto one record/seat. In that case (or when the extension id is missing) we key
+  // on the email, which is reliably per-user. The sanitized AZ username is the final
+  // fallback since it is always present.
+  const emailKey = rcUserEmail ? rcUserEmail.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') : '';
+  const usernameKey = String(username).trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+  const perUserKey =
+    (rcExtensionId && String(rcExtensionId) !== String(rcAccountId)) ? String(rcExtensionId)
+      : (emailKey || usernameKey || (rcExtensionId ? String(rcExtensionId) : ''));
+  const userId = (rcAccountId && perUserKey)
+    ? `az-user-${rcAccountId}-${perUserKey}`
+    : `az-user-${rcAccountId || 'noacct'}-${perUserKey || 'unknown'}`;
+  const displayName = rcUserName || rcUserEmail || username || 'AgencyZoom User';
+
+  // Always log the resolved RC identity (no secrets) so the per-user key can be verified.
+  console.log('[AgencyZoom][getUserInfo] RC identity', {
+    additionalInfoKeys: Object.keys(additionalInfo ?? {}),
+    rcAccountId,
+    rcExtensionId,
+    extIdSameAsAccount: !!(rcExtensionId && String(rcExtensionId) === String(rcAccountId)),
+    hasRcUserName: !!rcUserName,
+    hasRcUserEmail: !!rcUserEmail,
+    userId
+  });
 
   apiLog.logStart('AgencyZoom', 'getUserInfo', { userId, username, rcAccountId });
 
@@ -189,8 +205,8 @@ async function getUserInfo({ hostname, additionalInfo }) {
           await models.customer.create({
             sysId: String(userId),
             companyId: company.id,
-            email: username || '',
-            firstname: username || 'AgencyZoom User',
+            email: rcUserEmail || username || '',
+            firstname: displayName,
             platform: 'gate6.agencyzoom',
             hostname,
             rcAccountId
@@ -207,7 +223,7 @@ async function getUserInfo({ hostname, additionalInfo }) {
       successful: true,
       platformUserInfo: {
         id: userId,
-        name: username,
+        name: displayName,
         email: username,
         overridingApiKey: token,
         platformAdditionalInfo: {

--- a/src/connectors/agencyzoom/index.ts
+++ b/src/connectors/agencyzoom/index.ts
@@ -118,7 +118,7 @@ async function getRefreshedAuthToken(user) {
 async function getUserInfo({ hostname, additionalInfo }) {
   // rcAccountId arrives via the manifest's rcAdditionalSubmission (auto from RC cached
   // data — no user prompt, no framework change).
-  const { username, password, rcAccountId } = additionalInfo ?? {};
+  const { username, password, rcAccountId, } = additionalInfo ?? {};
 
   if (!hostname || !username || !password) {
     return {
@@ -143,6 +143,63 @@ async function getUserInfo({ hostname, additionalInfo }) {
 
   try {
     const token = await authenticate(username, password);
+
+    // License / seat enforcement (mirrors ServiceTitan getUserInfo). Runs after a successful
+    // login so a failed authentication never consumes a seat; a DB error degrades gracefully
+    // (logged, login still allowed) so it can't lock out an otherwise-licensed user.
+    if (models && models.companies && models.customer && rcAccountId) {
+      try {
+        const company = await models.companies.findOne({
+          where: { rcAccountId: String(rcAccountId), status: true },
+          raw: true
+        });
+        if (!company) {
+          return {
+            successful: false,
+            returnMessage: {
+              messageType: 'error',
+              message: 'No active subscription found for this account. Please contact Gate6 support.',
+              ttl: 5000
+            }
+          };
+        }
+
+        const existingCustomer = await models.customer.findOne({
+          where: { companyId: company.id, sysId: String(userId) },
+          raw: true
+        });
+
+        if (!existingCustomer) {
+          const currentSeatCount = await models.customer.count({
+            where: { companyId: company.id }
+          });
+
+          const maxSeats = Number(company.maxAllowedUsers);
+          if (Number.isFinite(maxSeats) && maxSeats >= 0 && currentSeatCount >= maxSeats) {
+            return {
+              successful: false,
+              returnMessage: {
+                messageType: 'error',
+                message: `License seat limit reached (${maxSeats} of ${maxSeats} in use). Contact your admin.`,
+                ttl: 5000
+              }
+            };
+          }
+
+          await models.customer.create({
+            sysId: String(userId),
+            companyId: company.id,
+            email: username || '',
+            firstname: username || 'AgencyZoom User',
+            platform: 'gate6.agencyzoom',
+            hostname,
+            rcAccountId
+          });
+        }
+      } catch (err) {
+        console.error('Error enforcing customer seat limits:', err);
+      }
+    }
 
     apiLog.logSuccess('AgencyZoom', 'getUserInfo', { userId, apiEndpoint: `${AZ_BASE_URL}/auth/login` });
 
@@ -642,7 +699,7 @@ async function getCallLog({ user, callLogId }) {
   let subject = subjectMatch ? subjectMatch[1].trim() : '';
 
   if (!subject || subject.toLowerCase().startsWith('direction:')) {
-      subject = '';
+    subject = '';
   }
 
   let agentNote = "";
@@ -893,4 +950,4 @@ exports.findContactWithName = findContactWithName;
 exports.getLogFormatType = getLogFormatType;
 exports.getRefreshedAuthToken = getRefreshedAuthToken;
 exports.getLicenseStatus = getLicenseStatus
-export {};
+export { };

--- a/src/connectors/monday/index.ts
+++ b/src/connectors/monday/index.ts
@@ -541,10 +541,13 @@ async function getUserInfo({ authHeader, hostname, query }) {
     // Discover the connector's single board once, at connect time, and store it so the
     // rest of the system reuses it without re-discovering.
     let boardId = null;
+    let boardName = null;
     try {
       const boards = await getCrmBoards({ accessToken, userId: null, operation: 'getUserInfo' });
-      boardId = pickDefaultBoard(boards)?.id || null;
-      console.log('[Monday][getUserInfo] selected board', { boardId, discoveredBoardCount: boards.length });
+      const defaultBoard = pickDefaultBoard(boards);
+      boardId = defaultBoard?.id || null;
+      boardName = defaultBoard?.name || null;
+      console.log('[Monday][getUserInfo] selected board', { boardId, boardName, discoveredBoardCount: boards.length });
     } catch (e) {
       console.warn('[Monday][getUserInfo] board discovery failed (will retry lazily):', e.message);
     }
@@ -558,7 +561,7 @@ async function getUserInfo({ authHeader, hostname, query }) {
         email: userData.email,
         overridingApiKey: accessToken,
         ...(cleanHostname ? { overridingHostname: cleanHostname } : {}),
-        platformAdditionalInfo: { ...(boardId ? { boardId } : {}) }
+        platformAdditionalInfo: { ...(boardId ? { boardId, boardName } : {}) }
       },
       returnMessage: { messageType: 'success', message: 'Successfully connected to Monday.', ttl: 3000 }
     };
@@ -570,6 +573,33 @@ async function getUserInfo({ authHeader, hostname, query }) {
       returnMessage: { messageType: 'error', message: 'Monday authentication failed.', ttl: 3000 }
     };
   }
+}
+
+// Runs right after the user record is saved during OAuth connect (before the extension
+// fetches user settings). Seed the contactBoardId setting here — the framework hardcodes
+// `userSettings: {}` on create, so this is the earliest point we can populate it. Seeding at
+// connect (rather than lazily in findContact/getBoardId) ensures the {contactBoardId} URL
+// token resolves on the very first call-pop without the user opening Settings to enter it.
+async function postSaveUserInfo({ userInfo, oauthApp }) {
+  try {
+    // saveUserInfo returns only { id, name } — NOT the Sequelize instance — so re-fetch the
+    // persisted user to read platformAdditionalInfo.boardId (stored by getUserInfo at connect)
+    // and write userSettings.contactBoardId before the extension loads settings.
+    const userId = userInfo?.id;
+    if (userId) {
+      const user = await UserModel.findByPk(userId);
+      const pai = user?.platformAdditionalInfo || user?.dataValues?.platformAdditionalInfo || {};
+      if (user && pai.boardId) {
+        await seedContactBoardIdSetting(user, String(pai.boardId));
+        console.log('[Monday][postSaveUserInfo] seeded contactBoardId at connect', { userId, boardId: pai.boardId });
+      } else {
+        console.warn('[Monday][postSaveUserInfo] no boardId on user record; contactBoardId not seeded', { userId, hasUser: !!user });
+      }
+    }
+  } catch (e: any) {
+    console.warn('[Monday][postSaveUserInfo] failed to seed contactBoardId:', e.message);
+  }
+  return userInfo;
 }
 
 async function unAuthorize({ user }) {
@@ -648,9 +678,43 @@ function getUserId(user) {
 // The connector uses a single board for everything. It is discovered once (the default
 // board with a Phone column), stored on the user record's platformAdditionalInfo, and
 // reused everywhere — no per-contact board lookup.
+// Self-labeling display value for a matched/created contact's `type`/`contactType`. Renders
+// as e.g. "Board: Sales Leads" so the board name is distinguishable from the numeric Monday
+// item (pulse) id shown alongside it. Falls back to the board id when the name is unknown
+// (e.g. users connected before boardName was persisted). Used only for display — the deep-link
+// URL resolves the board via the {contactBoardId} setting and logging reads the persisted id.
+function boardDisplayLabel({ boardName, boardId }: { boardName?: any, boardId?: any }) {
+  const val = boardName || (boardId != null ? String(boardId) : '');
+  return val ? `Board: ${val}` : '';
+}
+
+// Auto-populate the per-user `contactBoardId` setting so the {contactBoardId} URL token
+// (contactPageUrl/logPageUrl/callPopUrl) resolves without the admin entering it manually.
+// The token reads from `userSettings.contactBoardId.value`. Written only when it differs, to
+// avoid redundant DB writes. This also backfills users whose board was persisted before the
+// feature existed.
+async function seedContactBoardIdSetting(user: any, boardId: string) {
+  if (!boardId || typeof user?.update !== 'function') return;
+  const current = user.userSettings || user.dataValues?.userSettings || {};
+  if (String(current?.contactBoardId?.value ?? '') === String(boardId)) return;
+  try {
+    const nextSettings = { ...current, contactBoardId: { value: String(boardId) } };
+    await user.update({ userSettings: nextSettings });
+    if (typeof user.changed === 'function') {
+      user.changed('userSettings', true);
+      if (typeof user.save === 'function') await user.save();
+    }
+    console.log('[Monday][board] seeded contactBoardId setting', { boardId });
+  } catch (e: any) {
+    console.warn('[Monday][board] failed to seed contactBoardId setting:', e.message);
+  }
+}
+
 async function getBoardId({ user, accessToken, operation = 'getBoardId' }) {
   const pai = user?.platformAdditionalInfo || user?.dataValues?.platformAdditionalInfo || {};
   if (pai.boardId) {
+    // Backfill the contactBoardId setting for users whose board was persisted earlier.
+    await seedContactBoardIdSetting(user, String(pai.boardId));
     return String(pai.boardId);
   }
   // Not stored yet — discover the default board and persist it on the user record.
@@ -660,7 +724,7 @@ async function getBoardId({ user, accessToken, operation = 'getBoardId' }) {
   console.log('[Monday][board] discovered board', { boardId, boardName: board?.name, discoveredBoardCount: boards.length });
   if (boardId && typeof user?.update === 'function') {
     try {
-      const nextPai = { ...pai, boardId };
+      const nextPai = { ...pai, boardId, boardName: board?.name || pai.boardName };
       await user.update({ platformAdditionalInfo: nextPai });
       // JSON columns don't always auto-flag as changed; force a save to be safe.
       if (typeof user.changed === 'function') {
@@ -671,6 +735,8 @@ async function getBoardId({ user, accessToken, operation = 'getBoardId' }) {
     } catch (e) {
       console.warn('[Monday][board] failed to persist boardId on user record:', e.message);
     }
+    // Seed the contactBoardId setting so the {contactBoardId} URL token resolves.
+    await seedContactBoardIdSetting(user, String(boardId));
   }
   return boardId;
 }
@@ -801,38 +867,48 @@ async function findContact({ phoneNumber, accessToken, authHeader, user, isExten
   }
 
   const resolvedAccessToken = authHeader?.replace('Bearer ', '') || accessToken || user?.accessToken
-  // Contacts can live on ANY board, so search every accessible CRM board (each active board
-  // with a Phone column), not just the single default board. Each match is tagged with the id
-  // of the board it was found on, so `type`/`contactType` (the {contactType} URL variable)
-  // points the "open contact" / "view call log" links at that contact's actual board.
-  let boards = []
+
+  // ── SINGLE-BOARD MODE ─────────────────────────────────────────────────────────────────
+  // Multi-board search is disabled for now. Contacts are matched against the connector's
+  // single default board. `boardId` is kept for logging; `type`/`contactType` now carry the
+  // board NAME (shown in the contact list) since the deep-link URL uses the {contactBoardId}
+  // setting token, not {contactType}. We also seed that setting from the resolved board.
+  //
+  // --- multi-board search (commented out; restore to search every board) ---
+  // let boards = []
+  // try { boards = await getCrmBoards({ accessToken: resolvedAccessToken, userId: getUserId(user) }) }
+  // catch (e) { return { successful: false, returnMessage: { messageType: 'warning', message: 'Monday is taking too long to respond. Please try again.', ttl: 3000 } } }
+  // const perBoardMatches = await Promise.all(boards.map(async board => { ... type: String(board.id) ... }))
+  // --------------------------------------------------------------------------
+  let board: any = null
   try {
-    boards = await getCrmBoards({ accessToken: resolvedAccessToken, userId: getUserId(user), operation: 'findContact' })
-  } catch (e) {
+    const boards = await getCrmBoards({ accessToken: resolvedAccessToken, userId: getUserId(user), operation: 'findContact' })
+    board = pickDefaultBoard(boards)
+  } catch (e: any) {
     // A board-discovery failure (e.g. a slow query hitting the request timeout) should not
     // surface as a hard error — tell the user to retry.
     console.warn('[Monday] findContact: board discovery failed', e.message)
     return { successful: false, returnMessage: { messageType: 'warning', message: 'Monday is taking too long to respond. Please try again.', ttl: 3000 } }
   }
-  if (!boards || boards.length === 0) {
+  if (!board) {
     return { successful: false, returnMessage: { messageType: 'error', message: 'No Monday board with a Phone column was found. Add a Phone column to your board and try again.', ttl: 3000 } }
   }
+  // Auto-populate the contactBoardId setting so the {contactBoardId} URL token resolves.
+  await seedContactBoardIdSetting(user, String(board.id))
 
+  const boardName = board.name || String(board.id)
   const phone = normalizePhone(phoneNumber)
-  const matchedContactInfo = []
+  const matchedContactInfo: any[] = []
 
   if (phone) {
-    // Search each board's Phone column in parallel, tagging every match with its board id.
-    const perBoardMatches = await Promise.all(boards.map(async board => {
-      const phoneColumnId = board.phoneColumnId || await getPhoneColumnId({ accessToken: resolvedAccessToken, boardId: board.id, operation: 'findContact' })
-      if (!phoneColumnId) return []
-      const items = await searchBoardByPhone({ accessToken: resolvedAccessToken, boardId: board.id, phoneColumnId, phone, operation: 'findContact' })
-      // The extension reads `type` off the contact to build the RC entity's contactType
-      // (contacts/match.js), which feeds the {contactType} URL variable. Set both names to be safe.
-      return items.map(item => ({ id: item.id, name: item.name, phone, type: String(board.id), contactType: String(board.id), boardId: board.id }))
-    }))
-    for (const boardMatches of perBoardMatches) {
-      matchedContactInfo.push(...boardMatches)
+    const phoneColumnId = board.phoneColumnId || await getPhoneColumnId({ accessToken: resolvedAccessToken, boardId: board.id })
+    if (phoneColumnId) {
+      const items = await searchBoardByPhone({ accessToken: resolvedAccessToken, boardId: board.id, phoneColumnId, phone })
+      const boardLabel = boardDisplayLabel({ boardName, boardId: board.id })
+      for (const item of items) {
+        // Display the board name (self-labeled "Board: …") in the contact list; keep boardId for logging.
+        matchedContactInfo.push({ id: item.id, name: item.name, phone, type: boardLabel, contactType: boardLabel, boardId: board.id, boardName })
+      }
     }
 
     if (matchedContactInfo.length === 0 && user?.rcAccountId) {
@@ -916,8 +992,11 @@ async function findContactWithName({ name, accessToken, authHeader, user }) {
   }
 
   // `type` feeds the RC entity contactType (contacts/match.js) → {contactType} URL var.
-  const matchedContactInfo = items.map(item => ({ id: item.id, name: item.name, type: String(boardId), contactType: String(boardId), boardId }))
-  apiLog.logSuccess('Monday', 'findContactWithName', { name: term, matchedCount: matchedContactInfo.length, boardId })
+  // Match findContact's display: board name (self-labeled), not the raw boardId.
+  const wnPai = user?.platformAdditionalInfo || user?.dataValues?.platformAdditionalInfo || {}
+  const wnBoardLabel = boardDisplayLabel({ boardName: wnPai.boardName, boardId })
+  const matchedContactInfo = items.map(item => ({ id: item.id, name: item.name, type: wnBoardLabel, contactType: wnBoardLabel, boardId, boardName: wnPai.boardName }))
+  console.log('[Monday] findContactWithName', { term, matches: matchedContactInfo.length })
 
   return { successful: true, matchedContactInfo }
 }
@@ -998,13 +1077,18 @@ async function createContact({ phoneNumber, newContactName, accessToken, authHea
 
   await trackAnalytics({ user, crm: 'Monday', event: 'contactCreated' });
 
+  const createdBoardName =
+    (user?.platformAdditionalInfo || user?.dataValues?.platformAdditionalInfo || {})?.boardName
+  const createdBoardLabel = boardDisplayLabel({ boardName: createdBoardName, boardId })
   return {
     contactInfo: {
       id: created.id,
       name: created.name,
-      // `type` feeds the RC entity contactType so logging/URLs target the right board.
-      type: String(boardId),
-      contactType: String(boardId),
+      // `type`/`contactType` carry the board name (self-labeled "Board: …") for display; `boardId`
+      // targets the board for logging, and the deep-link URL resolves the board via the
+      // {contactBoardId} setting.
+      type: createdBoardLabel,
+      contactType: createdBoardLabel,
       boardId
     },
     returnMessage: {
@@ -1040,10 +1124,12 @@ async function createCallLog({ contactInfo, callLog, note, aiNote, transcript, a
     authHeader?.replace('Bearer ', '') || accessToken || user?.accessToken
   // Log directly against the contact passed in — like ServiceTitan/ServiceNow — instead of
   // re-querying Monday for the board. create_update only needs the item id (contactInfo.id),
-  // so no board lookup ("search") is needed on the main path. The board id is carried on the
-  // contact (smuggled via `type`); it's only needed for an optional recording upload, which
-  // resolves it lazily below. This keeps logging working even if board discovery is slow/down.
-  const boardId = String(contactInfo?.boardId || contactInfo?.type || '') || null;
+  // so no board lookup ("search") is needed on the main path. The board id is only needed for
+  // an optional recording upload, which resolves it lazily below. In single-board mode we read
+  // the persisted board id off the user record (no API call) — `contactInfo.type` now carries
+  // the board NAME for display, so it can no longer double as the board id.
+  const persistedPai = user?.platformAdditionalInfo || user?.dataValues?.platformAdditionalInfo || {};
+  const boardId = String(contactInfo?.boardId || persistedPai.boardId || '') || null;
   // Fall back to a generated subject when no custom subject is supplied — matches every
   // other connector (clio/insightly/netsuite) and avoids the blank "Subject:" line.
   const defaultSubject = `${callLog.direction} Call ${callLog.direction === 'Outbound' ? 'to' : 'from'} ${contactInfo?.name || 'contact'}`
@@ -1350,6 +1436,24 @@ async function updateCallLog({ existingCallLog, recordingLink, recordingDownload
   }
 
   const body = lines.join("<br>").replace(/^(<br>)+|(<br>)+$/g, '');
+
+  // ---- Recording Upload (recording-sync) ----
+  // RingCentral recordings are usually NOT ready when the call is first logged, so
+  // createCallLog's upload is skipped and the recording only arrives here, on the later
+  // recording-sync, as `recordingDownloadLink`. Upload it now so the MP3 lands in the board's
+  // Files column. Dedupe against the case where the recording WAS ready at create: if the
+  // existing log body already has a Recording section (`parsed.recording`), createCallLog
+  // already handled the file — skip to avoid a duplicate upload.
+  if (recordingDownloadLink && !parsed.recording && itemId && (user.userSettings?.addCallLogRecording?.value ?? true)) {
+    try {
+      const uploadBoardId = await resolveBoardId({ accessToken: resolvedAccessToken, user })
+      const fileName = `Call-${Date.now()}.mp3`
+      const s3Url = await downloadAudioFile(recordingDownloadLink, process.env.S3_BUCKET, fileName)
+      await uploadToMonday({ s3Url, accessToken: resolvedAccessToken, itemId, fileName, boardId: uploadBoardId })
+    } catch (e: any) {
+      console.warn('[Monday][updateCallLog] recording upload failed:', e.message)
+    }
+  }
 
   // 2. Edit the existing update if we could read it.
   if (canEditExisting) {
@@ -2000,6 +2104,7 @@ exports.getAuthType = getAuthType;
 exports.getOauthInfo = getOauthInfo;
 exports.getOverridingOAuthOption = getOverridingOAuthOption;
 exports.getUserInfo = getUserInfo;
+exports.postSaveUserInfo = postSaveUserInfo;
 exports.unAuthorize = unAuthorize;
 exports.findContact = findContact;
 exports.findContactWithName = findContactWithName;

--- a/src/connectors/monday/index.ts
+++ b/src/connectors/monday/index.ts
@@ -468,10 +468,13 @@ async function getUserInfo({ authHeader, hostname, query }) {
     // Discover the connector's single board once, at connect time, and store it so the
     // rest of the system reuses it without re-discovering.
     let boardId = null;
+    let boardName = null;
     try {
       const boards = await getCrmBoards({ accessToken, userId: null });
-      boardId = pickDefaultBoard(boards)?.id || null;
-      console.log('[Monday][getUserInfo] selected board', { boardId, discoveredBoardCount: boards.length });
+      const defaultBoard = pickDefaultBoard(boards);
+      boardId = defaultBoard?.id || null;
+      boardName = defaultBoard?.name || null;
+      console.log('[Monday][getUserInfo] selected board', { boardId, boardName, discoveredBoardCount: boards.length });
     } catch (e) {
       console.warn('[Monday][getUserInfo] board discovery failed (will retry lazily):', e.message);
     }
@@ -484,7 +487,7 @@ async function getUserInfo({ authHeader, hostname, query }) {
         email: userData.email,
         overridingApiKey: accessToken,
         ...(cleanHostname ? { overridingHostname: cleanHostname } : {}),
-        platformAdditionalInfo: { ...(boardId ? { boardId } : {}) }
+        platformAdditionalInfo: { ...(boardId ? { boardId, boardName } : {}) }
       },
       returnMessage: { messageType: 'success', message: 'Successfully connected to Monday.', ttl: 3000 }
     };
@@ -496,6 +499,33 @@ async function getUserInfo({ authHeader, hostname, query }) {
       returnMessage: { messageType: 'error', message: 'Monday authentication failed.', ttl: 3000 }
     };
   }
+}
+
+// Runs right after the user record is saved during OAuth connect (before the extension
+// fetches user settings). Seed the contactBoardId setting here — the framework hardcodes
+// `userSettings: {}` on create, so this is the earliest point we can populate it. Seeding at
+// connect (rather than lazily in findContact/getBoardId) ensures the {contactBoardId} URL
+// token resolves on the very first call-pop without the user opening Settings to enter it.
+async function postSaveUserInfo({ userInfo, oauthApp }) {
+  try {
+    // saveUserInfo returns only { id, name } — NOT the Sequelize instance — so re-fetch the
+    // persisted user to read platformAdditionalInfo.boardId (stored by getUserInfo at connect)
+    // and write userSettings.contactBoardId before the extension loads settings.
+    const userId = userInfo?.id;
+    if (userId) {
+      const user = await UserModel.findByPk(userId);
+      const pai = user?.platformAdditionalInfo || user?.dataValues?.platformAdditionalInfo || {};
+      if (user && pai.boardId) {
+        await seedContactBoardIdSetting(user, String(pai.boardId));
+        console.log('[Monday][postSaveUserInfo] seeded contactBoardId at connect', { userId, boardId: pai.boardId });
+      } else {
+        console.warn('[Monday][postSaveUserInfo] no boardId on user record; contactBoardId not seeded', { userId, hasUser: !!user });
+      }
+    }
+  } catch (e: any) {
+    console.warn('[Monday][postSaveUserInfo] failed to seed contactBoardId:', e.message);
+  }
+  return userInfo;
 }
 
 async function unAuthorize({ user }) {
@@ -572,9 +602,43 @@ function getUserId(user) {
 // The connector uses a single board for everything. It is discovered once (the default
 // board with a Phone column), stored on the user record's platformAdditionalInfo, and
 // reused everywhere — no per-contact board lookup.
+// Self-labeling display value for a matched/created contact's `type`/`contactType`. Renders
+// as e.g. "Board: Sales Leads" so the board name is distinguishable from the numeric Monday
+// item (pulse) id shown alongside it. Falls back to the board id when the name is unknown
+// (e.g. users connected before boardName was persisted). Used only for display — the deep-link
+// URL resolves the board via the {contactBoardId} setting and logging reads the persisted id.
+function boardDisplayLabel({ boardName, boardId }: { boardName?: any, boardId?: any }) {
+  const val = boardName || (boardId != null ? String(boardId) : '');
+  return val ? `Board: ${val}` : '';
+}
+
+// Auto-populate the per-user `contactBoardId` setting so the {contactBoardId} URL token
+// (contactPageUrl/logPageUrl/callPopUrl) resolves without the admin entering it manually.
+// The token reads from `userSettings.contactBoardId.value`. Written only when it differs, to
+// avoid redundant DB writes. This also backfills users whose board was persisted before the
+// feature existed.
+async function seedContactBoardIdSetting(user: any, boardId: string) {
+  if (!boardId || typeof user?.update !== 'function') return;
+  const current = user.userSettings || user.dataValues?.userSettings || {};
+  if (String(current?.contactBoardId?.value ?? '') === String(boardId)) return;
+  try {
+    const nextSettings = { ...current, contactBoardId: { value: String(boardId) } };
+    await user.update({ userSettings: nextSettings });
+    if (typeof user.changed === 'function') {
+      user.changed('userSettings', true);
+      if (typeof user.save === 'function') await user.save();
+    }
+    console.log('[Monday][board] seeded contactBoardId setting', { boardId });
+  } catch (e: any) {
+    console.warn('[Monday][board] failed to seed contactBoardId setting:', e.message);
+  }
+}
+
 async function getBoardId({ user, accessToken }) {
   const pai = user?.platformAdditionalInfo || user?.dataValues?.platformAdditionalInfo || {};
   if (pai.boardId) {
+    // Backfill the contactBoardId setting for users whose board was persisted earlier.
+    await seedContactBoardIdSetting(user, String(pai.boardId));
     return String(pai.boardId);
   }
   // Not stored yet — discover the default board and persist it on the user record.
@@ -584,7 +648,7 @@ async function getBoardId({ user, accessToken }) {
   console.log('[Monday][board] discovered board', { boardId, boardName: board?.name, discoveredBoardCount: boards.length });
   if (boardId && typeof user?.update === 'function') {
     try {
-      const nextPai = { ...pai, boardId };
+      const nextPai = { ...pai, boardId, boardName: board?.name || pai.boardName };
       await user.update({ platformAdditionalInfo: nextPai });
       // JSON columns don't always auto-flag as changed; force a save to be safe.
       if (typeof user.changed === 'function') {
@@ -595,6 +659,8 @@ async function getBoardId({ user, accessToken }) {
     } catch (e) {
       console.warn('[Monday][board] failed to persist boardId on user record:', e.message);
     }
+    // Seed the contactBoardId setting so the {contactBoardId} URL token resolves.
+    await seedContactBoardIdSetting(user, String(boardId));
   }
   return boardId;
 }
@@ -723,38 +789,48 @@ async function findContact({ phoneNumber, accessToken, authHeader, user, isExten
   }
 
   const resolvedAccessToken = authHeader?.replace('Bearer ', '') || accessToken || user?.accessToken
-  // Contacts can live on ANY board, so search every accessible CRM board (each active board
-  // with a Phone column), not just the single default board. Each match is tagged with the id
-  // of the board it was found on, so `type`/`contactType` (the {contactType} URL variable)
-  // points the "open contact" / "view call log" links at that contact's actual board.
-  let boards = []
+
+  // ── SINGLE-BOARD MODE ─────────────────────────────────────────────────────────────────
+  // Multi-board search is disabled for now. Contacts are matched against the connector's
+  // single default board. `boardId` is kept for logging; `type`/`contactType` now carry the
+  // board NAME (shown in the contact list) since the deep-link URL uses the {contactBoardId}
+  // setting token, not {contactType}. We also seed that setting from the resolved board.
+  //
+  // --- multi-board search (commented out; restore to search every board) ---
+  // let boards = []
+  // try { boards = await getCrmBoards({ accessToken: resolvedAccessToken, userId: getUserId(user) }) }
+  // catch (e) { return { successful: false, returnMessage: { messageType: 'warning', message: 'Monday is taking too long to respond. Please try again.', ttl: 3000 } } }
+  // const perBoardMatches = await Promise.all(boards.map(async board => { ... type: String(board.id) ... }))
+  // --------------------------------------------------------------------------
+  let board: any = null
   try {
-    boards = await getCrmBoards({ accessToken: resolvedAccessToken, userId: getUserId(user) })
-  } catch (e) {
+    const boards = await getCrmBoards({ accessToken: resolvedAccessToken, userId: getUserId(user) })
+    board = pickDefaultBoard(boards)
+  } catch (e: any) {
     // A board-discovery failure (e.g. a slow query hitting the request timeout) should not
     // surface as a hard error — tell the user to retry.
     console.warn('[Monday] findContact: board discovery failed', e.message)
     return { successful: false, returnMessage: { messageType: 'warning', message: 'Monday is taking too long to respond. Please try again.', ttl: 3000 } }
   }
-  if (!boards || boards.length === 0) {
+  if (!board) {
     return { successful: false, returnMessage: { messageType: 'error', message: 'No Monday board with a Phone column was found. Add a Phone column to your board and try again.', ttl: 3000 } }
   }
+  // Auto-populate the contactBoardId setting so the {contactBoardId} URL token resolves.
+  await seedContactBoardIdSetting(user, String(board.id))
 
+  const boardName = board.name || String(board.id)
   const phone = normalizePhone(phoneNumber)
-  const matchedContactInfo = []
+  const matchedContactInfo: any[] = []
 
   if (phone) {
-    // Search each board's Phone column in parallel, tagging every match with its board id.
-    const perBoardMatches = await Promise.all(boards.map(async board => {
-      const phoneColumnId = board.phoneColumnId || await getPhoneColumnId({ accessToken: resolvedAccessToken, boardId: board.id })
-      if (!phoneColumnId) return []
+    const phoneColumnId = board.phoneColumnId || await getPhoneColumnId({ accessToken: resolvedAccessToken, boardId: board.id })
+    if (phoneColumnId) {
       const items = await searchBoardByPhone({ accessToken: resolvedAccessToken, boardId: board.id, phoneColumnId, phone })
-      // The extension reads `type` off the contact to build the RC entity's contactType
-      // (contacts/match.js), which feeds the {contactType} URL variable. Set both names to be safe.
-      return items.map(item => ({ id: item.id, name: item.name, phone, type: String(board.id), contactType: String(board.id), boardId: board.id }))
-    }))
-    for (const boardMatches of perBoardMatches) {
-      matchedContactInfo.push(...boardMatches)
+      const boardLabel = boardDisplayLabel({ boardName, boardId: board.id })
+      for (const item of items) {
+        // Display the board name (self-labeled "Board: …") in the contact list; keep boardId for logging.
+        matchedContactInfo.push({ id: item.id, name: item.name, phone, type: boardLabel, contactType: boardLabel, boardId: board.id, boardName })
+      }
     }
 
     if (matchedContactInfo.length === 0 && user?.rcAccountId) {
@@ -835,7 +911,10 @@ async function findContactWithName({ name, accessToken, authHeader, user }) {
   }
 
   // `type` feeds the RC entity contactType (contacts/match.js) → {contactType} URL var.
-  const matchedContactInfo = items.map(item => ({ id: item.id, name: item.name, type: String(boardId), contactType: String(boardId), boardId }))
+  // Match findContact's display: board name (self-labeled), not the raw boardId.
+  const wnPai = user?.platformAdditionalInfo || user?.dataValues?.platformAdditionalInfo || {}
+  const wnBoardLabel = boardDisplayLabel({ boardName: wnPai.boardName, boardId })
+  const matchedContactInfo = items.map(item => ({ id: item.id, name: item.name, type: wnBoardLabel, contactType: wnBoardLabel, boardId, boardName: wnPai.boardName }))
   console.log('[Monday] findContactWithName', { term, matches: matchedContactInfo.length })
 
   return { successful: true, matchedContactInfo }
@@ -915,13 +994,18 @@ async function createContact({ phoneNumber, newContactName, accessToken, authHea
 
   await trackAnalytics({ user, crm: 'Monday', event: 'contactCreated' });
 
+  const createdBoardName =
+    (user?.platformAdditionalInfo || user?.dataValues?.platformAdditionalInfo || {})?.boardName
+  const createdBoardLabel = boardDisplayLabel({ boardName: createdBoardName, boardId })
   return {
     contactInfo: {
       id: created.id,
       name: created.name,
-      // `type` feeds the RC entity contactType so logging/URLs target the right board.
-      type: String(boardId),
-      contactType: String(boardId),
+      // `type`/`contactType` carry the board name (self-labeled "Board: …") for display; `boardId`
+      // targets the board for logging, and the deep-link URL resolves the board via the
+      // {contactBoardId} setting.
+      type: createdBoardLabel,
+      contactType: createdBoardLabel,
       boardId
     },
     returnMessage: {
@@ -956,10 +1040,12 @@ async function createCallLog({ contactInfo, callLog, note, aiNote, transcript, a
     authHeader?.replace('Bearer ', '') || accessToken || user?.accessToken
   // Log directly against the contact passed in — like ServiceTitan/ServiceNow — instead of
   // re-querying Monday for the board. create_update only needs the item id (contactInfo.id),
-  // so no board lookup ("search") is needed on the main path. The board id is carried on the
-  // contact (smuggled via `type`); it's only needed for an optional recording upload, which
-  // resolves it lazily below. This keeps logging working even if board discovery is slow/down.
-  const boardId = String(contactInfo?.boardId || contactInfo?.type || '') || null;
+  // so no board lookup ("search") is needed on the main path. The board id is only needed for
+  // an optional recording upload, which resolves it lazily below. In single-board mode we read
+  // the persisted board id off the user record (no API call) — `contactInfo.type` now carries
+  // the board NAME for display, so it can no longer double as the board id.
+  const persistedPai = user?.platformAdditionalInfo || user?.dataValues?.platformAdditionalInfo || {};
+  const boardId = String(contactInfo?.boardId || persistedPai.boardId || '') || null;
   // Fall back to a generated subject when no custom subject is supplied — matches every
   // other connector (clio/insightly/netsuite) and avoids the blank "Subject:" line.
   const defaultSubject = `${callLog.direction} Call ${callLog.direction === 'Outbound' ? 'to' : 'from'} ${contactInfo?.name || 'contact'}`
@@ -1094,7 +1180,7 @@ async function createCallLog({ contactInfo, callLog, note, aiNote, transcript, a
   }
 }
 
-async function updateCallLog({ existingCallLog, recordingLink, note, aiNote, transcript, accessToken, authHeader, user, subject, duration, startTime, result }) {
+async function updateCallLog({ existingCallLog, recordingLink, recordingDownloadLink, note, aiNote, transcript, accessToken, authHeader, user, subject, duration, startTime, result }) {
   const licenseError = await validateLicenseOrFail(user, 'updateCallLog');
   if (licenseError) return licenseError;
 
@@ -1238,6 +1324,24 @@ async function updateCallLog({ existingCallLog, recordingLink, note, aiNote, tra
   }
 
   const body = lines.join("<br>").replace(/^(<br>)+|(<br>)+$/g, '');
+
+  // ---- Recording Upload (recording-sync) ----
+  // RingCentral recordings are usually NOT ready when the call is first logged, so
+  // createCallLog's upload is skipped and the recording only arrives here, on the later
+  // recording-sync, as `recordingDownloadLink`. Upload it now so the MP3 lands in the board's
+  // Files column. Dedupe against the case where the recording WAS ready at create: if the
+  // existing log body already has a Recording section (`parsed.recording`), createCallLog
+  // already handled the file — skip to avoid a duplicate upload.
+  if (recordingDownloadLink && !parsed.recording && itemId && (user.userSettings?.addCallLogRecording?.value ?? true)) {
+    try {
+      const uploadBoardId = await resolveBoardId({ accessToken: resolvedAccessToken, user })
+      const fileName = `Call-${Date.now()}.mp3`
+      const s3Url = await downloadAudioFile(recordingDownloadLink, process.env.S3_BUCKET, fileName)
+      await uploadToMonday({ s3Url, accessToken: resolvedAccessToken, itemId, fileName, boardId: uploadBoardId })
+    } catch (e: any) {
+      console.warn('[Monday][updateCallLog] recording upload failed:', e.message)
+    }
+  }
 
   // 2. Edit the existing update if we could read it.
   if (canEditExisting) {
@@ -1805,6 +1909,7 @@ exports.getAuthType = getAuthType;
 exports.getOauthInfo = getOauthInfo;
 exports.getOverridingOAuthOption = getOverridingOAuthOption;
 exports.getUserInfo = getUserInfo;
+exports.postSaveUserInfo = postSaveUserInfo;
 exports.unAuthorize = unAuthorize;
 exports.findContact = findContact;
 exports.findContactWithName = findContactWithName;

--- a/src/connectors/monday/index.ts
+++ b/src/connectors/monday/index.ts
@@ -39,6 +39,51 @@ function stringifyForLog(value, maxLength = 1200) {
 
 apiLog.installErrorInterceptor(mondayApiClient, 'Monday');
 
+// AI notes arrive with markdown bold markers (**Recap**, **Tasks**) which Monday updates
+// don't render — they show as literal asterisks. Strip them for clean plain text.
+function stripMarkdownBold(text) {
+  return text ? String(text).replace(/\*\*/g, '') : text;
+}
+
+// Format a timestamp with the user's chosen date format from the extension settings
+// (userSettings.logDateFormat — one of RC's six formats, e.g. 'MM/DD/YYYY hh:mm:ss A'),
+// applying the user's timezone offset the same way core's callLogComposer does.
+function formatDateTime({ user, time }) {
+  let momentTime = moment(time);
+  const tz = user?.timezoneOffset;
+  if (tz) {
+    momentTime = (typeof tz === 'string' && tz.includes(':'))
+      ? momentTime.utcOffset(tz)
+      : momentTime.utcOffset(Number(tz));
+  }
+  return momentTime.format(user?.userSettings?.logDateFormat?.value || 'YYYY-MM-DD hh:mm:ss A');
+}
+
+// Core builds a tokenized download link for fax attachments but NOT for voicemail —
+// connectors only get the media-reader page link, which 401s server-side. Build the
+// tokenized link ourselves from the message's AudioRecording attachment uri plus the
+// RC access token stamped onto the message by the /messageLog wrapper in src/index.ts.
+function getVoicemailDownloadLink(message) {
+  const audio = message?.attachments?.find?.(a => a.type === 'AudioRecording');
+  if (audio?.uri && message?.rcAccessToken) {
+    return `${audio.uri}${audio.uri.includes('?') ? '&' : '?'}access_token=${message.rcAccessToken}`;
+  }
+  return null;
+}
+
+// A recording link may be the media-reader PAGE (https://ringcentral.github.io/
+// ringcentral-media-reader/?media=<real media url>) rather than the raw media content.
+// Downloading the page yields HTML — that's how "recordings" ended up as .htm files in
+// Monday. Unwrap the real media URL before downloading.
+function resolveMediaContentUrl(link) {
+  try {
+    const mediaParam = new URL(link).searchParams.get('media');
+    return mediaParam || link;
+  } catch (e) {
+    return link;
+  }
+}
+
 // Normalize a hostname to the bare host the companies table stores:
 // strips scheme (http/https), any path/query, port, and trailing slash; lowercased.
 function normalizeHostname(raw) {
@@ -84,13 +129,15 @@ function hasTransientMondayError(errors) {
   });
 }
 
-async function mondayRequest(accessToken, query, variables = {}, { maxAttempts = 2 } = {}) {
+// `operation` names the connector function making the call (e.g. 'createCallLog') so every
+// API log line is attributable — same idea as ServiceTitan's `_operation` axios tag.
+async function mondayRequest(accessToken, query, variables = {}, { maxAttempts = 2, operation = 'unknown' } = {}) {
   const reqId = ++mondayApiCallCounter;
   const op = describeGraphqlOperation(query);
   let lastBody = null;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     const startedAt = Date.now();
-    console.log(attempt === 1 ? '[Monday][api] →' : '[Monday][api] ↻ retry', { reqId, op, attempt, ...(attempt === 1 ? { variables: stringifyForLog(variables, 600) } : {}) });
+    console.log(attempt === 1 ? '[Monday][api] →' : '[Monday][api] ↻ retry', { reqId, operation, op, attempt, ...(attempt === 1 ? { variables: stringifyForLog(variables, 600) } : {}) });
     try {
       const res = await mondayApiClient.post(
         MONDAY_API_URL,
@@ -99,7 +146,8 @@ async function mondayRequest(accessToken, query, variables = {}, { maxAttempts =
           headers: {
             Authorization: `Bearer ${accessToken}`,
             'Content-Type': 'application/json'
-          }
+          },
+          _operation: operation
         }
       );
       const ms = Date.now() - startedAt;
@@ -108,19 +156,19 @@ async function mondayRequest(accessToken, query, variables = {}, { maxAttempts =
       // Monday returns GraphQL errors with HTTP 200, so they bypass the axios
       // interceptor — surface them explicitly here.
       if (body?.errors?.length) {
-        console.error('[Monday][api] ✗ GraphQL error', { reqId, op, ms, attempt, errors: stringifyForLog(body.errors, 1000) });
+        console.error('[Monday][api] ✗ GraphQL error', { reqId, operation, op, ms, attempt, variables: stringifyForLog(variables, 600), errors: stringifyForLog(body.errors, 1000) });
         if (hasTransientMondayError(body.errors) && attempt < maxAttempts) {
           await sleep(400 * attempt);
           continue;
         }
       } else {
-        console.log('[Monday][api] ←', { reqId, op, ms, dataKeys: body?.data ? Object.keys(body.data) : [] });
+        console.log('[Monday][api] ←', { reqId, operation, op, ms, dataKeys: body?.data ? Object.keys(body.data) : [] });
       }
       return body;
     } catch (err) {
       const ms = Date.now() - startedAt;
       const status = err?.response?.status || null;
-      console.error('[Monday][api] ✗ HTTP error', { reqId, op, ms, attempt, status, message: err?.message || '', responseBody: stringifyForLog(err?.response?.data, 1000) });
+      console.error('[Monday][api] ✗ HTTP error', { reqId, operation, op, ms, attempt, status, message: err?.message || '', variables: stringifyForLog(variables, 600), responseBody: stringifyForLog(err?.response?.data, 1000) });
       // Retry transient transport failures (5xx, timeout, network) too.
       const transient = !status || status >= 500 || err?.code === 'ECONNABORTED';
       if (transient && attempt < maxAttempts) {
@@ -148,11 +196,12 @@ function isNumericMondayId(id) {
   return id != null && /^\d+$/.test(String(id));
 }
 
-async function getOrCreateCallLogsColumn({ accessToken, boardId, columnName = 'Call Logs' }) {
+async function getOrCreateCallLogsColumn({ accessToken, boardId, columnName = 'Call Logs', operation = 'getOrCreateCallLogsColumn' }) {
   let columnId = await getColumnIdByName({
     accessToken,
     boardId,
-    columnName
+    columnName,
+    operation
   })
 
   if (columnId) {
@@ -175,7 +224,8 @@ async function getOrCreateCallLogsColumn({ accessToken, boardId, columnName = 'C
     {
       boardId: Number(boardId),
       title: columnName
-    }
+    },
+    { operation }
   )
 
   if (!res?.data?.create_column?.id) {
@@ -189,11 +239,12 @@ async function getOrCreateCallLogsColumn({ accessToken, boardId, columnName = 'C
   return newColumnId
 }
 
-async function getOrCreateFilesColumn({ accessToken, boardId, columnName = 'Files' }) {
+async function getOrCreateFilesColumn({ accessToken, boardId, columnName = 'Files', operation = 'getOrCreateFilesColumn' }) {
   let columnId = await getColumnIdByName({
     accessToken,
     boardId,
-    columnName
+    columnName,
+    operation
   })
 
   if (columnId) {
@@ -216,7 +267,8 @@ async function getOrCreateFilesColumn({ accessToken, boardId, columnName = 'File
     {
       boardId: Number(boardId),
       title: columnName
-    }
+    },
+    { operation }
   )
 
   if (!res?.data?.create_column?.id) {
@@ -231,7 +283,7 @@ async function getOrCreateFilesColumn({ accessToken, boardId, columnName = 'File
   return newColumnId
 }
 
-async function getColumnIdByName({ accessToken, boardId, columnName }) {
+async function getColumnIdByName({ accessToken, boardId, columnName, operation = 'getColumnIdByName' }) {
   if (!columnName) {
     return null
   }
@@ -258,7 +310,8 @@ async function getColumnIdByName({ accessToken, boardId, columnName }) {
       }
     }
     `,
-    { boardId: Number(boardId) }
+    { boardId: Number(boardId) },
+    { operation }
   )
   const boardData = res?.data?.boards?.[0]
   const columns = boardData?.columns || []
@@ -336,14 +389,15 @@ async function getOauthInfo() {
     clientSecret: process.env.MONDAY_CLIENT_SECRET,
     accessTokenUri: process.env.MONDAY_TOKEN_URI,
     redirectUri: process.env.REDIRECT_URI,
-    scopes: ['me:read', 'users:read', 'boards:read', 'boards:write', 'updates:write']
+    scopes: ['me:read', 'users:read', 'boards:read', 'boards:write', 'updates:write', 'account:read']
   };
 }
 
 async function getUserInfo({ authHeader, hostname, query }) {
+  console.log("Hostname : ", hostname)
   // OAuth callback already provides `query` with rcAccountId — no framework change needed.
   const rcAccountId = query?.rcAccountId;
-  console.log("Rc AccountId", rcAccountId)
+  apiLog.logStart('Monday', 'getUserInfo', { rcAccountId, hostname });
   try {
     const accessToken = authHeader.replace('Bearer ', '');
     if (!accessToken) {
@@ -353,23 +407,34 @@ async function getUserInfo({ authHeader, hostname, query }) {
       };
     }
 
-    console.log('[Monday][api] → query me (getUserInfo)');
-    const userDataResponse = await mondayApiClient.post(
-      MONDAY_API_URL,
-      { query: "query { me { id name email } }" },
-      {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-          "Content-Type": "application/json"
+    // Ask for account.slug too (the account the token was issued for). If the token lacks
+    // the scope for the account field, retry with the plain `me` query so connect never
+    // breaks — we just lose the slug and fall back to the extension-provided hostname.
+    const meQuery = async (query) => {
+      const response = await mondayApiClient.post(
+        MONDAY_API_URL,
+        { query },
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            "Content-Type": "application/json"
+          },
+          _operation: 'getUserInfo'
         }
-      }
-    );
+      );
+      return response.data;
+    };
 
-    const result = userDataResponse.data;
+    console.log('[Monday][api] → query me (getUserInfo)');
+    let result = await meQuery("query { me { id name email account { slug } } }");
+    if (result?.errors?.length || !result?.data?.me) {
+      console.warn('[Monday][getUserInfo] me query with account.slug failed — retrying without it', stringifyForLog(result?.errors, 800));
+      result = await meQuery("query { me { id name email } }");
+    }
     if (result?.errors?.length) {
       console.error('[Monday][api] ✗ GraphQL error (getUserInfo me)', stringifyForLog(result.errors, 800));
     } else {
-      console.log('[Monday][api] ← query me (getUserInfo)', { meId: result?.data?.me?.id });
+      console.log('[Monday][api] ← query me (getUserInfo)', { meId: result?.data?.me?.id, accountSlug: result?.data?.me?.account?.slug });
     }
     if (!result?.data?.me) {
       return {
@@ -389,11 +454,18 @@ async function getUserInfo({ authHeader, hostname, query }) {
       email: result.data.me.email
     };
 
-    // Normalize the hostname (admin may enter a full URL in the managed-OAuth form)
-    // so it is stored as a bare host — required for the license lookup and for the
-    // {hostname} URL templates to resolve correctly.
-    const cleanHostname = normalizeHostname(hostname);
-    console.log('[Monday][getUserInfo] hostname normalized', { rawHostname: hostname, cleanHostname });
+    // Derive the hostname from the account the token was ACTUALLY issued for (me.account.slug),
+    // not from what the extension passed in. The extension's dynamic-environment hostname is
+    // sticky (first workspace URL it saw) and auth.monday.com authorizes the user's active
+    // session account — both can disagree with the account the user meant to connect. The
+    // slug is authoritative: token, hostname and {hostname} URL templates always match.
+    const accountSlug = result?.data?.me?.account?.slug || null;
+    const slugHostname = accountSlug ? `${accountSlug}.monday.com` : null;
+    if (!slugHostname) {
+      console.warn('[Monday][getUserInfo] me.account.slug missing — falling back to extension-provided hostname', { rawHostname: hostname });
+    }
+    const cleanHostname = normalizeHostname(slugHostname || hostname);
+    console.log('[Monday][getUserInfo] hostname resolved', { accountSlug, rawHostname: hostname, cleanHostname });
 
     // Company / customer onboarding — mirrors the ServiceTitan pattern so that each
     // connecting user is registered in the `customer` table with a `companyId` FK.
@@ -410,6 +482,7 @@ async function getUserInfo({ authHeader, hostname, query }) {
             raw: true
           });
         }
+        console.log("Company: ", company)
         if (!company) {
           company = await models.companies.findOne({
             where: { rcAccountId: String(rcAccountId), status: true },
@@ -479,6 +552,7 @@ async function getUserInfo({ authHeader, hostname, query }) {
       console.warn('[Monday][getUserInfo] board discovery failed (will retry lazily):', e.message);
     }
 
+    apiLog.logSuccess('Monday', 'getUserInfo', { userId: userData.id, boardId, hostname: cleanHostname });
     return {
       successful: true,
       platformUserInfo: {
@@ -548,7 +622,7 @@ async function unAuthorize({ user }) {
 
 // Discover the CRM boards a connected user can access — any active board that has a
 // Phone column. Results are cached briefly per user to avoid repeated board lookups.
-async function getCrmBoards({ accessToken, userId }) {
+async function getCrmBoards({ accessToken, userId, operation = 'getCrmBoards' }) {
   const now = Date.now();
   const cached = userId ? boardCache.get(userId) : null;
   if (cached && cached.expiry > now) {
@@ -565,7 +639,9 @@ async function getCrmBoards({ accessToken, userId }) {
         columns { id title type }
       }
     }
-    `
+    `,
+    {},
+    { operation }
   );
 
   const rawBoards = res?.data?.boards || [];
@@ -642,7 +718,7 @@ async function getBoardId({ user, accessToken }) {
     return String(pai.boardId);
   }
   // Not stored yet — discover the default board and persist it on the user record.
-  const boards = await getCrmBoards({ accessToken, userId: getUserId(user) });
+  const boards = await getCrmBoards({ accessToken, userId: getUserId(user), operation });
   const board = pickDefaultBoard(boards);
   const boardId = board?.id || null;
   console.log('[Monday][board] discovered board', { boardId, boardName: board?.name, discoveredBoardCount: boards.length });
@@ -667,15 +743,15 @@ async function getBoardId({ user, accessToken }) {
 
 // Logging always targets the connector's single board (read stored, else discover).
 // This does not depend on contactInfo.type surviving the extension round-trip.
-async function resolveBoardId({ accessToken, user }) {
-  const boardId = await getBoardId({ user, accessToken });
-  console.log('[Monday][board] resolveBoardId ->', { boardId });
+async function resolveBoardId({ accessToken, user, operation = 'resolveBoardId' }) {
+  const boardId = await getBoardId({ user, accessToken, operation });
+  console.log('[Monday][board] resolveBoardId ->', { boardId, operation });
   return boardId;
 }
 
 // The Phone column id for a board, cached via getColumnIdByName.
-async function getPhoneColumnId({ accessToken, boardId }) {
-  return getColumnIdByName({ accessToken, boardId, columnName: 'Phone' });
+async function getPhoneColumnId({ accessToken, boardId, operation = 'getPhoneColumnId' }) {
+  return getColumnIdByName({ accessToken, boardId, columnName: 'Phone', operation });
 }
 
 function parseMondayCallLogBody(body = '') {
@@ -739,7 +815,7 @@ function parseMondayCallLogBody(body = '') {
   }
 }
 
-async function searchBoardByPhone({ accessToken, boardId, phoneColumnId, phone }) {
+async function searchBoardByPhone({ accessToken, boardId, phoneColumnId, phone, operation = 'findContact' }) {
   // Try formats in priority order (Monday's "+1 623 201 1816" first) and STOP at the
   // first format that matches — best case is a single query. Each request is bounded by
   // the client timeout and try/caught, so a slow/failed format is skipped, not fatal.
@@ -758,7 +834,8 @@ async function searchBoardByPhone({ accessToken, boardId, phoneColumnId, phone }
           }
         }
         `,
-        { value: searchValue }
+        { value: searchValue },
+        { operation }
       )
       if (res?.errors?.length) {
         console.warn('[Monday] searchBoardByPhone error on board', boardId, res.errors[0].message)
@@ -777,6 +854,7 @@ async function searchBoardByPhone({ accessToken, boardId, phoneColumnId, phone }
 }
 
 async function findContact({ phoneNumber, accessToken, authHeader, user, isExtension }) {
+  apiLog.logStart('Monday', 'findContact', { phoneNumber, isExtension });
   const licenseError = await validateLicenseOrFail(user, 'findContact');
   if (licenseError) return licenseError;
 
@@ -852,10 +930,12 @@ async function findContact({ phoneNumber, accessToken, authHeader, user, isExten
     isNewContact: true
   })
 
+  apiLog.logSuccess('Monday', 'findContact', { phoneNumber, matchedCount: matchedContactInfo.length - 1, boardsSearched: boards.length });
   return { successful: true, matchedContactInfo }
 }
 
 async function findContactWithName({ name, accessToken, authHeader, user }) {
+  apiLog.logStart('Monday', 'findContactWithName', { name });
   const licenseError = await validateLicenseOrFail(user, 'findContactWithName');
   if (licenseError) return licenseError;
 
@@ -870,7 +950,7 @@ async function findContactWithName({ name, accessToken, authHeader, user }) {
   // "Contact search by name failed". Degrade to an empty result instead.
   let boardId = null
   try {
-    boardId = await getBoardId({ user, accessToken: resolvedAccessToken })
+    boardId = await getBoardId({ user, accessToken: resolvedAccessToken, operation: 'findContactWithName' })
   } catch (e) {
     console.warn('[Monday] findContactWithName: board resolution failed', e.message)
     return { successful: true, matchedContactInfo: [] }
@@ -899,7 +979,8 @@ async function findContactWithName({ name, accessToken, authHeader, user }) {
         }
       }
       `,
-      { boardId: [boardId] }
+      { boardId: [boardId] },
+      { operation: 'findContactWithName' }
     )
     if (res?.errors?.length) {
       console.warn('[Monday] findContactWithName error on board', boardId, res.errors[0].message)
@@ -921,12 +1002,13 @@ async function findContactWithName({ name, accessToken, authHeader, user }) {
 }
 
 async function createContact({ phoneNumber, newContactName, accessToken, authHeader, user }) {
+  apiLog.logStart('Monday', 'createContact', { phoneNumber, newContactName });
   const licenseError = await validateLicenseOrFail(user, 'createContact');
   if (licenseError) return licenseError;
 
   const resolvedAccessToken = authHeader?.replace('Bearer ', '') || accessToken || user?.accessToken
-  const boardId = await getBoardId({ user, accessToken: resolvedAccessToken })
-  const phoneColumnId = boardId ? await getPhoneColumnId({ accessToken: resolvedAccessToken, boardId }) : null
+  const boardId = await getBoardId({ user, accessToken: resolvedAccessToken, operation: 'createContact' })
+  const phoneColumnId = boardId ? await getPhoneColumnId({ accessToken: resolvedAccessToken, boardId, operation: 'createContact' }) : null
   if (!boardId || !phoneColumnId) {
     return {
       contactInfo: null,
@@ -969,7 +1051,8 @@ async function createContact({ phoneNumber, newContactName, accessToken, authHea
       {
         name: newContactName,
         values: JSON.stringify({ [phoneColumnId]: variant })
-      }
+      },
+      { operation: 'createContact' }
     )
     if (!res?.errors?.length && res?.data?.create_item?.id) {
       created = res.data.create_item
@@ -990,7 +1073,7 @@ async function createContact({ phoneNumber, newContactName, accessToken, authHea
     }
   }
 
-  console.log('[Monday][createContact] created item', { itemId: created.id, boardId })
+  apiLog.logSuccess('Monday', 'createContact', { contactId: created.id, boardId })
 
   await trackAnalytics({ user, crm: 'Monday', event: 'contactCreated' });
 
@@ -1033,6 +1116,7 @@ async function getMondayUserName(user) {
 }
 
 async function createCallLog({ contactInfo, callLog, note, aiNote, transcript, accessToken, authHeader, user }) {
+  apiLog.logStart('Monday', 'createCallLog', { contactId: contactInfo?.id, direction: callLog?.direction, duration: callLog?.duration, sessionId: callLog?.sessionId, hasRecording: !!callLog?.recording?.downloadUrl });
   const licenseError = await validateLicenseOrFail(user, 'createCallLog');
   if (licenseError) return licenseError;
 
@@ -1063,7 +1147,7 @@ async function createCallLog({ contactInfo, callLog, note, aiNote, transcript, a
     sections.push(`Recording:<br>${callLog.recording.link}`)
   }
   if (aiNote && (user.userSettings?.addCallLogAiNote?.value ?? true)) {
-    sections.push(`AI Note:<br>${aiNote.replace(/\r?\n/g, '<br>')}`)
+    sections.push(`AI Note:<br>${stripMarkdownBold(aiNote).replace(/\r?\n/g, '<br>')}`)
   }
   if (transcript && (user.userSettings?.addCallLogTranscript?.value ?? true)) {
     sections.push(`Transcript:<br>${transcript.replace(/\r?\n/g, '<br>')}`)
@@ -1104,9 +1188,9 @@ async function createCallLog({ contactInfo, callLog, note, aiNote, transcript, a
 
   const footerLines = [];
   if (callLog.startTime && (user.userSettings?.addCallLogDateTime?.value ?? true)) {
-    footerLines.push(`Start Time: ${moment(callLog.startTime).format("YYYY-MM-DD HH:mm:ss")}`);
+    footerLines.push(`Start Time: ${formatDateTime({ user, time: callLog.startTime })}`);
     if (callLog.duration) {
-      footerLines.push(`End Time: ${moment(callLog.startTime).add(callLog.duration, "seconds").format("YYYY-MM-DD HH:mm:ss")}`);
+      footerLines.push(`End Time: ${formatDateTime({ user, time: moment(callLog.startTime).add(callLog.duration, "seconds") })}`);
     }
   }
 
@@ -1134,7 +1218,8 @@ async function createCallLog({ contactInfo, callLog, note, aiNote, transcript, a
     {
       itemId: Number(contactInfo.id),
       body
-    }
+    },
+    { operation: 'createCallLog' }
   )
   assertNoGraphqlErrors(res, `createCallLog (create_update itemId=${contactInfo.id})`)
 
@@ -1142,14 +1227,14 @@ async function createCallLog({ contactInfo, callLog, note, aiNote, transcript, a
   if (!updateId) {
     throw new Error(`Monday createCallLog: create_update returned no id for itemId=${contactInfo.id}`)
   }
-  console.log('[Monday][createCallLog] created update', { updateId, itemId: Number(contactInfo.id), boardId })
+  apiLog.logSuccess('Monday', 'createCallLog', { logId: updateId, contactId: Number(contactInfo.id), boardId })
 
   // ---- Recording Upload ----
   // Only here is the board id actually needed. Use the one carried on the contact; resolve
   // it lazily (one query) only if it wasn't provided, so the call log itself never blocks on
   // board discovery.
   if (callLog?.recording?.downloadUrl) {
-    const uploadBoardId = boardId || await resolveBoardId({ accessToken: resolvedAccessToken, user })
+    const uploadBoardId = boardId || await resolveBoardId({ accessToken: resolvedAccessToken, user, operation: 'createCallLog' })
     const fileName = `Call-${Date.now()}.mp3`
     const s3Key = fileName
     const s3Url = await downloadAudioFile(
@@ -1158,13 +1243,15 @@ async function createCallLog({ contactInfo, callLog, note, aiNote, transcript, a
       s3Key
     )
 
-    await uploadToMonday({
-      s3Url,
-      accessToken: resolvedAccessToken,
-      itemId: Number(contactInfo.id),
-      fileName,
-      boardId: uploadBoardId
-    })
+    if (s3Url) {
+      await uploadToMonday({
+        s3Url,
+        accessToken: resolvedAccessToken,
+        itemId: Number(contactInfo.id),
+        fileName,
+        boardId: uploadBoardId
+      })
+    }
   }
 
   await trackAnalytics({ user, crm: 'Monday', event: 'callLogCreated', eventDate: callLog?.startTime });
@@ -1188,10 +1275,12 @@ async function updateCallLog({ existingCallLog, recordingLink, recordingDownload
     authHeader?.replace('Bearer ', '') || accessToken || user?.accessToken
   const logId = existingCallLog?.thirdPartyLogId
   const itemId = Number(existingCallLog?.contactId)
-  console.log('[Monday][updateCallLog] start', {
-    thirdPartyLogId: logId,
+  apiLog.logStart('Monday', 'updateCallLog', {
+    logId,
     contactId: existingCallLog?.contactId,
-    isNumericId: isNumericMondayId(logId)
+    isNumericId: isNumericMondayId(logId),
+    hasRecordingLink: !!recordingLink,
+    hasRecordingDownloadLink: !!recordingDownloadLink
   })
 
   // 1. Read the existing update so we can merge with it — only if the stored id is a
@@ -1210,7 +1299,8 @@ async function updateCallLog({ existingCallLog, recordingLink, recordingDownload
           }
         }
         `,
-        { updateId: [logId] }
+        { updateId: [logId] },
+        { operation: 'updateCallLog' }
       )
       if (res?.errors?.length) {
         console.warn('[Monday][updateCallLog] could not read existing update; will recreate', { logId })
@@ -1261,7 +1351,7 @@ async function updateCallLog({ existingCallLog, recordingLink, recordingDownload
     sections.push(`Recording:<br>${effectiveRecording}`)
   }
   if (effectiveAiNote && (user.userSettings?.addCallLogAiNote?.value ?? true)) {
-    sections.push(`AI Note:<br>${effectiveAiNote.replace(/\r?\n/g, '<br>')}`)
+    sections.push(`AI Note:<br>${stripMarkdownBold(effectiveAiNote).replace(/\r?\n/g, '<br>')}`)
   }
   if (effectiveTranscript && (user.userSettings?.addCallLogTranscript?.value ?? true)) {
     sections.push(`Transcript:<br>${effectiveTranscript.replace(/\r?\n/g, '<br>')}`)
@@ -1271,9 +1361,9 @@ async function updateCallLog({ existingCallLog, recordingLink, recordingDownload
   let endTimeToUse = parsed.endTime
 
   if (startTime) {
-    startTimeToUse = moment(startTime).format("YYYY-MM-DD HH:mm:ss")
+    startTimeToUse = formatDateTime({ user, time: startTime })
     if (duration) {
-      endTimeToUse = moment(startTime).add(duration, "seconds").format("YYYY-MM-DD HH:mm:ss")
+      endTimeToUse = formatDateTime({ user, time: moment(startTime).add(duration, "seconds") })
     }
   }
 
@@ -1355,9 +1445,17 @@ async function updateCallLog({ existingCallLog, recordingLink, recordingDownload
           }
         }
         `,
-        { updateId: logId, body }
+        { updateId: logId, body },
+        { operation: 'updateCallLog' }
       )
       if (!updateRes?.errors?.length && updateRes?.data?.edit_update?.id) {
+        // Attach the recording file only when a NEW recording link arrived (the old body not
+        // already carrying it) — otherwise every later edit would re-upload a duplicate file.
+        // Prefer the tokenized download link; the display link is the fallback.
+        if (recordingLink && recordingLink !== parsed.recording) {
+          await uploadCallRecording({ accessToken: resolvedAccessToken, user, itemId, recordingLink: recordingDownloadLink || recordingLink })
+        }
+        apiLog.logSuccess('Monday', 'updateCallLog', { logId: updateRes.data.edit_update.id, contactId: existingCallLog?.contactId, mode: 'edited' });
         await trackAnalytics({ user, crm: 'Monday', event: 'callLogUpdated', eventDate: startTime });
         return {
           logId: updateRes.data.edit_update.id,
@@ -1384,14 +1482,18 @@ async function updateCallLog({ existingCallLog, recordingLink, recordingDownload
       }
     }
     `,
-    { itemId, body }
+    { itemId, body },
+    { operation: 'updateCallLog' }
   )
   assertNoGraphqlErrors(createRes, 'updateCallLog (create_update fallback)')
   const newLogId = createRes?.data?.create_update?.id
   if (!newLogId) {
     throw new Error('Monday updateCallLog: fallback create_update returned no id')
   }
-  console.log('[Monday][updateCallLog] recreated update', { oldLogId: logId, newLogId, itemId })
+  apiLog.logSuccess('Monday', 'updateCallLog', { logId: newLogId, oldLogId: logId, contactId: itemId, mode: 'recreated' })
+  if (recordingLink && recordingLink !== parsed.recording) {
+    await uploadCallRecording({ accessToken: resolvedAccessToken, user, itemId, recordingLink: recordingDownloadLink || recordingLink })
+  }
   // Repoint the stored id so the next update edits this new update instead of recreating.
   try {
     if (typeof existingCallLog?.update === 'function') {
@@ -1410,6 +1512,7 @@ async function updateCallLog({ existingCallLog, recordingLink, recordingDownload
 }
 
 async function getCallLog({ callLogId, accessToken, authHeader, user }) {
+  apiLog.logStart('Monday', 'getCallLog', { logId: callLogId });
   const licenseError = await validateLicenseOrFail(user, 'getCallLog');
   if (licenseError) return licenseError;
 
@@ -1436,7 +1539,8 @@ async function getCallLog({ callLogId, accessToken, authHeader, user }) {
       }
     }
     `,
-    { updateId: [callLogId] }
+    { updateId: [callLogId] },
+    { operation: 'getCallLog' }
   )
 
   if (res?.errors?.length || !res?.data?.updates?.length) {
@@ -1458,6 +1562,7 @@ async function getCallLog({ callLogId, accessToken, authHeader, user }) {
   const rawBody = update.body || ''
   const parsed = parseMondayCallLogBody(rawBody)
 
+  apiLog.logSuccess('Monday', 'getCallLog', { logId: callLogId })
   return {
     callLogInfo: {
       subject: parsed.subject,
@@ -1477,17 +1582,19 @@ async function upsertCallDisposition({ existingCallLog }) {
   return { logId: existingCallLog.thirdPartyLogId }
 }
 
-async function createMessageLog({ user, contactInfo, message, recordingLink, faxDocLink, accessToken }) {
+async function createMessageLog({ user, contactInfo, message, recordingLink, recordingDownloadLink, faxDocLink, faxDownloadLink, accessToken }) {
+  apiLog.logStart('Monday', 'createMessageLog', { contactId: contactInfo?.id, direction: message?.direction, hasRecording: !!recordingLink, hasRecordingDownloadLink: !!recordingDownloadLink, hasFax: !!faxDocLink });
   const licenseError = await validateLicenseOrFail(user, 'createMessageLog');
   if (licenseError) return licenseError;
 
   const resolvedAccessToken = accessToken || user?.accessToken
-  const boardId = await resolveBoardId({ accessToken: resolvedAccessToken, user });
+  const boardId = await resolveBoardId({ accessToken: resolvedAccessToken, user, operation: 'createMessageLog' });
   const itemId = Number(contactInfo.id)
   const callLogsColumnId = await getOrCreateCallLogsColumn({
     accessToken: resolvedAccessToken,
     boardId,
-    columnName: 'Call Logs'
+    columnName: 'Call Logs',
+    operation: 'createMessageLog'
   })
   const messageType =
     recordingLink ? 'Voicemail' : (faxDocLink ? 'Fax' : 'SMS')
@@ -1500,7 +1607,7 @@ async function createMessageLog({ user, contactInfo, message, recordingLink, fax
         : 'You'
     const text = message.subject || message.text || ''
     body = `SMS conversation with ${contactInfo.name}<br>`
-    body += `[${moment(message.creationTime || Date.now()).format('YYYY-MM-DD HH:mm:ss')}] ${sender}: ${text}<br>`
+    body += `[${formatDateTime({ user, time: message.creationTime || Date.now() })}] ${sender}: ${text}<br>`
 
   }
 
@@ -1524,7 +1631,8 @@ async function createMessageLog({ user, contactInfo, message, recordingLink, fax
     {
       itemId,
       body
-    }
+    },
+    { operation: 'createMessageLog' }
   )
 
   if (!res?.data?.create_update?.id) {
@@ -1553,12 +1661,15 @@ async function createMessageLog({ user, contactInfo, message, recordingLink, fax
         itemId,
         columnId: callLogsColumnId,
         value: body
-      }
+      },
+      { operation: 'createMessageLog' }
     )
   }
 
   if (recordingLink || faxDocLink) {
-    const downloadUrl = recordingLink || faxDocLink
+    // Prefer the tokenized download links — the display links (media-reader pages)
+    // have no access token and 401 when downloaded server-side.
+    const downloadUrl = recordingDownloadLink || faxDownloadLink || getVoicemailDownloadLink(message) || recordingLink || faxDocLink
     const fileName =
       recordingLink
         ? `Voicemail-${Date.now()}.mp3`
@@ -1570,17 +1681,20 @@ async function createMessageLog({ user, contactInfo, message, recordingLink, fax
       s3Key
     )
 
-    await uploadToMonday({
-      s3Url,
-      accessToken: resolvedAccessToken,
-      itemId,
-      fileName,
-      boardId
-    })
+    if (s3Url) {
+      await uploadToMonday({
+        s3Url,
+        accessToken: resolvedAccessToken,
+        itemId,
+        fileName,
+        boardId
+      })
+    }
   }
 
   await trackAnalytics({ user, crm: 'Monday', event: 'messageLogCreated', eventDate: message?.creationTime });
 
+  apiLog.logSuccess('Monday', 'createMessageLog', { logId: updateId, contactId: itemId, messageType, boardId })
   return {
     logId: updateId,
     contactId: itemId,
@@ -1592,19 +1706,21 @@ async function createMessageLog({ user, contactInfo, message, recordingLink, fax
   }
 }
 
-async function updateMessageLog({ user, contactInfo, existingMessageLog, message, recordingLink, faxDocLink, accessToken }) {
+async function updateMessageLog({ user, contactInfo, existingMessageLog, message, recordingLink, recordingDownloadLink, faxDocLink, faxDownloadLink, accessToken }) {
+  apiLog.logStart('Monday', 'updateMessageLog', { contactId: contactInfo?.id, logId: existingMessageLog?.thirdPartyLogId, direction: message?.direction, hasRecording: !!recordingLink, hasFax: !!faxDocLink });
   const licenseError = await validateLicenseOrFail(user, 'updateMessageLog');
   if (licenseError) return licenseError;
 
   const MAX_THREAD_MESSAGES = 10
   const resolvedAccessToken = accessToken || user?.accessToken
-  const boardId = await resolveBoardId({ accessToken: resolvedAccessToken, user });
+  const boardId = await resolveBoardId({ accessToken: resolvedAccessToken, user, operation: 'updateMessageLog' });
   const itemId = Number(contactInfo.id)
   const updateId = existingMessageLog.thirdPartyLogId
   const callLogsColumnId = await getOrCreateCallLogsColumn({
     accessToken: resolvedAccessToken,
     boardId,
-    columnName: 'Call Logs'
+    columnName: 'Call Logs',
+    operation: 'updateMessageLog'
   })
   const messageType =
     recordingLink ? 'Voicemail' : (faxDocLink ? 'Fax' : 'SMS')
@@ -1635,13 +1751,15 @@ async function updateMessageLog({ user, contactInfo, existingMessageLog, message
       {
         itemId,
         body
-      }
+      },
+      { operation: 'updateMessageLog' }
     )
 
     const newUpdateId = res.data.create_update.id
 
     await trackAnalytics({ user, crm: 'Monday', event: 'messageLogUpdated', eventDate: message?.creationTime });
 
+    apiLog.logSuccess('Monday', 'updateMessageLog', { logId: newUpdateId, contactId: itemId, messageType })
     return {
       logId: newUpdateId,
       returnMessage: {
@@ -1666,7 +1784,8 @@ async function updateMessageLog({ user, contactInfo, existingMessageLog, message
       }
     }
     `,
-    { updateId: [updateId] }
+    { updateId: [updateId] },
+    { operation: 'updateMessageLog' }
   )
 
   const previousBody =
@@ -1676,8 +1795,10 @@ async function updateMessageLog({ user, contactInfo, existingMessageLog, message
       ? contactInfo.name
       : 'You'
   const text = message.subject || message.text || ''
-  const newLine =
-    `<br>[${moment(message.creationTime || Date.now()).format('YYYY-MM-DD HH:mm:ss')}] ${sender}: ${text}<br>`
+  // No leading/trailing <br> on the message line itself — junction breaks are added
+  // explicitly below, so messages are separated by exactly ONE line break (the old
+  // `<br>…<br>` pattern doubled up into a blank line between every message).
+  const newLine = `[${formatDateTime({ user, time: message.creationTime || Date.now() })}] ${sender}: ${text}`
   const messageLines =
     previousBody
       .split('<br>')
@@ -1686,44 +1807,77 @@ async function updateMessageLog({ user, contactInfo, existingMessageLog, message
   let updatedBody
   let response
   let newThreadId = updateId
+  // On a thread reset (>= MAX messages) the old update stays as history; otherwise the
+  // new update carries the merged history forward and the old one is deleted.
+  let shouldDeleteOld = false
 
   if (messageCount >= MAX_THREAD_MESSAGES) {
     updatedBody =
-      `SMS conversation with ${contactInfo.name}<br>` +
-      `[${moment(message.creationTime || Date.now()).format('YYYY-MM-DD HH:mm:ss')}] ${sender}: ${text}<br>`
-    response = await mondayRequest(
-      resolvedAccessToken,
-      `
-      mutation ($itemId: ID!, $body: String!) {
-        create_update(item_id: $itemId, body: $body) {
-          id
-        }
-      }
-      `,
-      {
-        itemId,
-        body: updatedBody
-      }
-    )
-
-    newThreadId = response.data.create_update.id
-
+      `SMS conversation with ${contactInfo.name}<br>${newLine}`
   } else {
-    updatedBody = previousBody + newLine
-    response = await mondayRequest(
-      resolvedAccessToken,
-      `
-      mutation ($updateId: ID!, $body: String!) {
-        edit_update(id: $updateId, body: $body) {
-          id
+    shouldDeleteOld = true
+    // Collapse legacy double breaks, then strip trailing breaks so the append adds
+    // exactly one line break — this also cleans up old threads on their next message.
+    const trimmedPrevious = previousBody
+      .replace(/(<br\s*\/?>)\s*(<br\s*\/?>)+/gi, '$1')
+      .replace(/(?:\s|<br\s*\/?>)+$/i, '')
+    updatedBody = trimmedPrevious
+      ? `${trimmedPrevious}<br>${newLine}`
+      : `SMS conversation with ${contactInfo.name}<br>${newLine}`
+  }
+
+  // Monday's updates feed is ordered by creation time and edit_update does NOT move an
+  // update up — so an ongoing conversation stayed buried under newer updates. Recreate
+  // the thread (create a fresh update with the full history, then delete the old one)
+  // so the conversation always surfaces on top.
+  response = await mondayRequest(
+    resolvedAccessToken,
+    `
+    mutation ($itemId: ID!, $body: String!) {
+      create_update(item_id: $itemId, body: $body) {
+        id
+      }
+    }
+    `,
+    {
+      itemId,
+      body: updatedBody
+    },
+    { operation: 'updateMessageLog' }
+  )
+  assertNoGraphqlErrors(response, 'updateMessageLog (create_update SMS thread)')
+  newThreadId = response?.data?.create_update?.id
+  if (!newThreadId) {
+    throw new Error('Monday updateMessageLog: create_update returned no id')
+  }
+
+  if (shouldDeleteOld && isNumericMondayId(updateId) && String(newThreadId) !== String(updateId)) {
+    try {
+      await mondayRequest(
+        resolvedAccessToken,
+        `
+        mutation ($updateId: ID!) {
+          delete_update(id: $updateId) {
+            id
+          }
         }
-      }
-      `,
-      {
-        updateId,
-        body: updatedBody
-      }
-    )
+        `,
+        { updateId },
+        { operation: 'updateMessageLog' }
+      )
+    } catch (e) {
+      console.warn('[Monday][updateMessageLog] failed to delete old thread update — a duplicate may remain', { oldUpdateId: updateId, message: e.message })
+    }
+  }
+
+  // Repoint the stored id so the next message appends to the recreated thread instead
+  // of a deleted update (which would restart the conversation and lose history).
+  if (String(newThreadId) !== String(updateId) && typeof existingMessageLog?.update === 'function') {
+    try {
+      await existingMessageLog.update({ thirdPartyLogId: String(newThreadId) })
+    } catch (e) {
+      console.warn('[Monday][updateMessageLog] failed to repoint thirdPartyLogId', { newThreadId, message: e.message })
+    }
   }
 
   if (callLogsColumnId) {
@@ -1746,12 +1900,15 @@ async function updateMessageLog({ user, contactInfo, existingMessageLog, message
         itemId,
         columnId: callLogsColumnId,
         value: updatedBody
-      }
+      },
+      { operation: 'updateMessageLog' }
     )
   }
 
   if (recordingLink || faxDocLink) {
-    const downloadUrl = recordingLink || faxDocLink
+    // Prefer the tokenized download links — the display links (media-reader pages)
+    // have no access token and 401 when downloaded server-side.
+    const downloadUrl = recordingDownloadLink || faxDownloadLink || getVoicemailDownloadLink(message) || recordingLink || faxDocLink
     const fileName =
       recordingLink
         ? `Voicemail-${Date.now()}.mp3`
@@ -1763,17 +1920,20 @@ async function updateMessageLog({ user, contactInfo, existingMessageLog, message
       s3Key
     )
 
-    await uploadToMonday({
-      s3Url,
-      accessToken: resolvedAccessToken,
-      itemId,
-      fileName,
-      boardId
-    })
+    if (s3Url) {
+      await uploadToMonday({
+        s3Url,
+        accessToken: resolvedAccessToken,
+        itemId,
+        fileName,
+        boardId
+      })
+    }
   }
 
   await trackAnalytics({ user, crm: 'Monday', event: 'messageLogUpdated', eventDate: message?.creationTime });
 
+  apiLog.logSuccess('Monday', 'updateMessageLog', { logId: newThreadId, contactId: itemId, messageType: 'SMS', appended: newThreadId === updateId })
   return {
     logId: newThreadId,
     returnMessage: {
@@ -1792,8 +1952,11 @@ async function getUserList() {
 }
 
 async function downloadAudioFile(url, s3Bucket, s3Key) {
+  // Unwrap media-reader page links to the raw media content URL (see resolveMediaContentUrl).
+  url = resolveMediaContentUrl(url);
   const urlObj = new URL(url);
-  const accessToken = urlObj.searchParams.get("accessToken");
+  // RC media links carry the token as either `accessToken` or `access_token`.
+  const accessToken = urlObj.searchParams.get("accessToken") || urlObj.searchParams.get("access_token");
   const s3Values = {
     accessKeyId: process.env.MEDIA_UPLOAD_KEY_ID,
     secretAccessKey: process.env.MEDIA_UPLOAD_SECRET_KEY,
@@ -1803,12 +1966,20 @@ async function downloadAudioFile(url, s3Bucket, s3Key) {
   console.log("Downloading Audio File...");
 
   try {
+    // Only send Authorization when we actually have a token — `Bearer null` makes RC
+    // reject the request even when the URL itself carries a valid query token.
     const response = await mondayApiClient.get(url, {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
+      headers: accessToken ? { Authorization: `Bearer ${accessToken}` } : {},
       responseType: "stream",
+      _operation: 'downloadAudioFile'
     });
+    // If we still got a web page instead of media, don't upload it — a .htm file in the
+    // Files column is worse than no file.
+    const contentType = response.headers?.['content-type'] || '';
+    if (contentType.includes('text/html')) {
+      console.warn('[Monday][downloadAudioFile] got HTML instead of media — skipping upload', { url: url.split('?')[0], contentType });
+      return null;
+    }
     const uploadParams = {
       Bucket: s3Bucket,
       Key: s3Key,
@@ -1828,7 +1999,8 @@ async function uploadToMonday({ s3Url, accessToken, itemId, fileName, boardId })
     console.log('[Monday][api] → file upload (add_file_to_column)', { itemId, boardId, fileName })
     const filesColumnId = await getOrCreateFilesColumn({
       accessToken,
-      boardId
+      boardId,
+      operation: 'uploadToMonday'
     })
 
     if (!filesColumnId) {
@@ -1856,7 +2028,7 @@ async function uploadToMonday({ s3Url, accessToken, itemId, fileName, boardId })
 
     formData.append('variables[file]', fileStream, {
       filename: fileName,
-      contentType: 'audio/mpeg'
+      contentType: fileName.toLowerCase().endsWith('.pdf') ? 'application/pdf' : 'audio/mpeg'
     })
 
     const response = await mondayApiClient.post(
@@ -1867,7 +2039,8 @@ async function uploadToMonday({ s3Url, accessToken, itemId, fileName, boardId })
           Authorization: `Bearer ${accessToken}`,
           ...formData.getHeaders()
         },
-        maxBodyLength: Infinity
+        maxBodyLength: Infinity,
+        _operation: 'uploadToMonday'
       }
     )
 

--- a/src/connectors/monday/index.ts
+++ b/src/connectors/monday/index.ts
@@ -394,7 +394,6 @@ async function getOauthInfo() {
 }
 
 async function getUserInfo({ authHeader, hostname, query }) {
-  console.log("Hostname : ", hostname)
   // OAuth callback already provides `query` with rcAccountId — no framework change needed.
   const rcAccountId = query?.rcAccountId;
   apiLog.logStart('Monday', 'getUserInfo', { rcAccountId, hostname });
@@ -482,7 +481,7 @@ async function getUserInfo({ authHeader, hostname, query }) {
             raw: true
           });
         }
-        console.log("Company: ", company)
+
         if (!company) {
           company = await models.companies.findOne({
             where: { rcAccountId: String(rcAccountId), status: true },

--- a/src/connectors/monday/index.ts
+++ b/src/connectors/monday/index.ts
@@ -343,6 +343,7 @@ async function getOauthInfo() {
 async function getUserInfo({ authHeader, hostname, query }) {
   // OAuth callback already provides `query` with rcAccountId — no framework change needed.
   const rcAccountId = query?.rcAccountId;
+  console.log("Rc AccountId", rcAccountId)
   try {
     const accessToken = authHeader.replace('Bearer ', '');
     if (!accessToken) {
@@ -722,16 +723,20 @@ async function findContact({ phoneNumber, accessToken, authHeader, user, isExten
   }
 
   const resolvedAccessToken = authHeader?.replace('Bearer ', '') || accessToken || user?.accessToken
-  let boardId = null
+  // Contacts can live on ANY board, so search every accessible CRM board (each active board
+  // with a Phone column), not just the single default board. Each match is tagged with the id
+  // of the board it was found on, so `type`/`contactType` (the {contactType} URL variable)
+  // points the "open contact" / "view call log" links at that contact's actual board.
+  let boards = []
   try {
-    boardId = await getBoardId({ user, accessToken: resolvedAccessToken })
+    boards = await getCrmBoards({ accessToken: resolvedAccessToken, userId: getUserId(user) })
   } catch (e) {
-    // A board-resolution failure (e.g. a slow discovery query hitting the request
-    // timeout) should not surface as a hard error — tell the user to retry.
-    console.warn('[Monday] findContact: board resolution failed', e.message)
+    // A board-discovery failure (e.g. a slow query hitting the request timeout) should not
+    // surface as a hard error — tell the user to retry.
+    console.warn('[Monday] findContact: board discovery failed', e.message)
     return { successful: false, returnMessage: { messageType: 'warning', message: 'Monday is taking too long to respond. Please try again.', ttl: 3000 } }
   }
-  if (!boardId) {
+  if (!boards || boards.length === 0) {
     return { successful: false, returnMessage: { messageType: 'error', message: 'No Monday board with a Phone column was found. Add a Phone column to your board and try again.', ttl: 3000 } }
   }
 
@@ -739,15 +744,17 @@ async function findContact({ phoneNumber, accessToken, authHeader, user, isExten
   const matchedContactInfo = []
 
   if (phone) {
-    const phoneColumnId = await getPhoneColumnId({ accessToken: resolvedAccessToken, boardId })
-    if (phoneColumnId) {
-      const items = await searchBoardByPhone({ accessToken: resolvedAccessToken, boardId, phoneColumnId, phone })
-      for (const item of items) {
-        // The extension reads `type` off the contact to build the RC entity's
-        // contactType (contacts/match.js), which feeds the {contactType} URL variable
-        // for both "view call log" and "open contact". Set both names to be safe.
-        matchedContactInfo.push({ id: item.id, name: item.name, phone, type: String(boardId), contactType: String(boardId), boardId })
-      }
+    // Search each board's Phone column in parallel, tagging every match with its board id.
+    const perBoardMatches = await Promise.all(boards.map(async board => {
+      const phoneColumnId = board.phoneColumnId || await getPhoneColumnId({ accessToken: resolvedAccessToken, boardId: board.id })
+      if (!phoneColumnId) return []
+      const items = await searchBoardByPhone({ accessToken: resolvedAccessToken, boardId: board.id, phoneColumnId, phone })
+      // The extension reads `type` off the contact to build the RC entity's contactType
+      // (contacts/match.js), which feeds the {contactType} URL variable. Set both names to be safe.
+      return items.map(item => ({ id: item.id, name: item.name, phone, type: String(board.id), contactType: String(board.id), boardId: board.id }))
+    }))
+    for (const boardMatches of perBoardMatches) {
+      matchedContactInfo.push(...boardMatches)
     }
 
     if (matchedContactInfo.length === 0 && user?.rcAccountId) {

--- a/src/connectors/monday/index.ts
+++ b/src/connectors/monday/index.ts
@@ -943,7 +943,7 @@ async function findContact({ phoneNumber, accessToken, authHeader, user, isExten
     isNewContact: true
   })
 
-  apiLog.logSuccess('Monday', 'findContact', { phoneNumber, matchedCount: matchedContactInfo.length - 1, boardsSearched: boards.length });
+  apiLog.logSuccess('Monday', 'findContact', { phoneNumber, matchedCount: matchedContactInfo.length - 1, boardId: board.id });
   return { successful: true, matchedContactInfo }
 }
 

--- a/src/connectors/monday/index.ts
+++ b/src/connectors/monday/index.ts
@@ -972,6 +972,17 @@ async function findContactWithName({ name, accessToken, authHeader, user }) {
     return { successful: true, matchedContactInfo: [] }
   }
 
+  // The interface contract (docs/developers/interfaces/findContactWithName.md) requires the
+  // same contact shape as findContact — including `phone`. Without it, the extension cannot
+  // reconcile a manually-selected contact with later phone-based lookups, so fetch the
+  // board's phone column value alongside id/name. A missing phone column is non-fatal.
+  let phoneColumnId = null
+  try {
+    phoneColumnId = await getPhoneColumnId({ accessToken: resolvedAccessToken, boardId, operation: 'findContactWithName' })
+  } catch (e) {
+    console.warn('[Monday] findContactWithName: phone column resolution failed', e.message)
+  }
+
   // Inline the search term via JSON.stringify so it is a safely-escaped GraphQL list
   // literal (e.g. ["O'Brien"]). compare_value is Monday's JSON CompareValue scalar.
   const compareValue = JSON.stringify([term])
@@ -981,18 +992,18 @@ async function findContactWithName({ name, accessToken, authHeader, user }) {
     const res = await mondayRequest(
       resolvedAccessToken,
       `
-      query ($boardId: [ID!]) {
+      query ($boardId: [ID!]${phoneColumnId ? ', $phoneColumnIds: [String!]' : ''}) {
         boards(ids: $boardId) {
           items_page(
             limit: 25,
             query_params: { rules: [{ column_id: "name", compare_value: ${compareValue}, operator: contains_text }] }
           ) {
-            items { id name }
+            items { id name${phoneColumnId ? ' column_values(ids: $phoneColumnIds) { text }' : ''} }
           }
         }
       }
       `,
-      { boardId: [boardId] },
+      { boardId: [boardId], ...(phoneColumnId ? { phoneColumnIds: [String(phoneColumnId)] } : {}) },
       { operation: 'findContactWithName' }
     )
     if (res?.errors?.length) {
@@ -1008,8 +1019,15 @@ async function findContactWithName({ name, accessToken, authHeader, user }) {
   // Match findContact's display: board name (self-labeled), not the raw boardId.
   const wnPai = user?.platformAdditionalInfo || user?.dataValues?.platformAdditionalInfo || {}
   const wnBoardLabel = boardDisplayLabel({ boardName: wnPai.boardName, boardId })
-  const matchedContactInfo = items.map(item => ({ id: item.id, name: item.name, type: wnBoardLabel, contactType: wnBoardLabel, boardId, boardName: wnPai.boardName }))
-  console.log('[Monday] findContactWithName', { term, matches: matchedContactInfo.length })
+  const matchedContactInfo = items.map(item => {
+    // Monday stores the phone column as display text (e.g. "+1 623 201 1816" or
+    // "16232011816"); normalize to E.164 where possible so it matches what findContact
+    // returns, falling back to the raw text rather than dropping the number.
+    const rawPhone = item.column_values?.[0]?.text?.trim() || ''
+    const phone = rawPhone ? (normalizePhone(rawPhone) || normalizePhone(`+${rawPhone.replace(/\D/g, '')}`) || rawPhone) : ''
+    return { id: item.id, name: item.name, phone, type: wnBoardLabel, contactType: wnBoardLabel, boardId, boardName: wnPai.boardName }
+  })
+  console.log('[Monday] findContactWithName', { term, matches: matchedContactInfo.length, withPhone: matchedContactInfo.filter(c => c.phone).length })
 
   return { successful: true, matchedContactInfo }
 }

--- a/src/connectors/monday/index.ts
+++ b/src/connectors/monday/index.ts
@@ -39,6 +39,51 @@ function stringifyForLog(value, maxLength = 1200) {
 
 apiLog.installErrorInterceptor(mondayApiClient, 'Monday');
 
+// AI notes arrive with markdown bold markers (**Recap**, **Tasks**) which Monday updates
+// don't render — they show as literal asterisks. Strip them for clean plain text.
+function stripMarkdownBold(text) {
+  return text ? String(text).replace(/\*\*/g, '') : text;
+}
+
+// Format a timestamp with the user's chosen date format from the extension settings
+// (userSettings.logDateFormat — one of RC's six formats, e.g. 'MM/DD/YYYY hh:mm:ss A'),
+// applying the user's timezone offset the same way core's callLogComposer does.
+function formatDateTime({ user, time }) {
+  let momentTime = moment(time);
+  const tz = user?.timezoneOffset;
+  if (tz) {
+    momentTime = (typeof tz === 'string' && tz.includes(':'))
+      ? momentTime.utcOffset(tz)
+      : momentTime.utcOffset(Number(tz));
+  }
+  return momentTime.format(user?.userSettings?.logDateFormat?.value || 'YYYY-MM-DD hh:mm:ss A');
+}
+
+// Core builds a tokenized download link for fax attachments but NOT for voicemail —
+// connectors only get the media-reader page link, which 401s server-side. Build the
+// tokenized link ourselves from the message's AudioRecording attachment uri plus the
+// RC access token stamped onto the message by the /messageLog wrapper in src/index.ts.
+function getVoicemailDownloadLink(message) {
+  const audio = message?.attachments?.find?.(a => a.type === 'AudioRecording');
+  if (audio?.uri && message?.rcAccessToken) {
+    return `${audio.uri}${audio.uri.includes('?') ? '&' : '?'}access_token=${message.rcAccessToken}`;
+  }
+  return null;
+}
+
+// A recording link may be the media-reader PAGE (https://ringcentral.github.io/
+// ringcentral-media-reader/?media=<real media url>) rather than the raw media content.
+// Downloading the page yields HTML — that's how "recordings" ended up as .htm files in
+// Monday. Unwrap the real media URL before downloading.
+function resolveMediaContentUrl(link) {
+  try {
+    const mediaParam = new URL(link).searchParams.get('media');
+    return mediaParam || link;
+  } catch (e) {
+    return link;
+  }
+}
+
 // Normalize a hostname to the bare host the companies table stores:
 // strips scheme (http/https), any path/query, port, and trailing slash; lowercased.
 function normalizeHostname(raw) {
@@ -84,13 +129,15 @@ function hasTransientMondayError(errors) {
   });
 }
 
-async function mondayRequest(accessToken, query, variables = {}, { maxAttempts = 2 } = {}) {
+// `operation` names the connector function making the call (e.g. 'createCallLog') so every
+// API log line is attributable — same idea as ServiceTitan's `_operation` axios tag.
+async function mondayRequest(accessToken, query, variables = {}, { maxAttempts = 2, operation = 'unknown' } = {}) {
   const reqId = ++mondayApiCallCounter;
   const op = describeGraphqlOperation(query);
   let lastBody = null;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     const startedAt = Date.now();
-    console.log(attempt === 1 ? '[Monday][api] →' : '[Monday][api] ↻ retry', { reqId, op, attempt, ...(attempt === 1 ? { variables: stringifyForLog(variables, 600) } : {}) });
+    console.log(attempt === 1 ? '[Monday][api] →' : '[Monday][api] ↻ retry', { reqId, operation, op, attempt, ...(attempt === 1 ? { variables: stringifyForLog(variables, 600) } : {}) });
     try {
       const res = await mondayApiClient.post(
         MONDAY_API_URL,
@@ -99,7 +146,8 @@ async function mondayRequest(accessToken, query, variables = {}, { maxAttempts =
           headers: {
             Authorization: `Bearer ${accessToken}`,
             'Content-Type': 'application/json'
-          }
+          },
+          _operation: operation
         }
       );
       const ms = Date.now() - startedAt;
@@ -108,19 +156,19 @@ async function mondayRequest(accessToken, query, variables = {}, { maxAttempts =
       // Monday returns GraphQL errors with HTTP 200, so they bypass the axios
       // interceptor — surface them explicitly here.
       if (body?.errors?.length) {
-        console.error('[Monday][api] ✗ GraphQL error', { reqId, op, ms, attempt, errors: stringifyForLog(body.errors, 1000) });
+        console.error('[Monday][api] ✗ GraphQL error', { reqId, operation, op, ms, attempt, variables: stringifyForLog(variables, 600), errors: stringifyForLog(body.errors, 1000) });
         if (hasTransientMondayError(body.errors) && attempt < maxAttempts) {
           await sleep(400 * attempt);
           continue;
         }
       } else {
-        console.log('[Monday][api] ←', { reqId, op, ms, dataKeys: body?.data ? Object.keys(body.data) : [] });
+        console.log('[Monday][api] ←', { reqId, operation, op, ms, dataKeys: body?.data ? Object.keys(body.data) : [] });
       }
       return body;
     } catch (err) {
       const ms = Date.now() - startedAt;
       const status = err?.response?.status || null;
-      console.error('[Monday][api] ✗ HTTP error', { reqId, op, ms, attempt, status, message: err?.message || '', responseBody: stringifyForLog(err?.response?.data, 1000) });
+      console.error('[Monday][api] ✗ HTTP error', { reqId, operation, op, ms, attempt, status, message: err?.message || '', variables: stringifyForLog(variables, 600), responseBody: stringifyForLog(err?.response?.data, 1000) });
       // Retry transient transport failures (5xx, timeout, network) too.
       const transient = !status || status >= 500 || err?.code === 'ECONNABORTED';
       if (transient && attempt < maxAttempts) {
@@ -148,11 +196,12 @@ function isNumericMondayId(id) {
   return id != null && /^\d+$/.test(String(id));
 }
 
-async function getOrCreateCallLogsColumn({ accessToken, boardId, columnName = 'Call Logs' }) {
+async function getOrCreateCallLogsColumn({ accessToken, boardId, columnName = 'Call Logs', operation = 'getOrCreateCallLogsColumn' }) {
   let columnId = await getColumnIdByName({
     accessToken,
     boardId,
-    columnName
+    columnName,
+    operation
   })
 
   if (columnId) {
@@ -175,7 +224,8 @@ async function getOrCreateCallLogsColumn({ accessToken, boardId, columnName = 'C
     {
       boardId: Number(boardId),
       title: columnName
-    }
+    },
+    { operation }
   )
 
   if (!res?.data?.create_column?.id) {
@@ -189,11 +239,12 @@ async function getOrCreateCallLogsColumn({ accessToken, boardId, columnName = 'C
   return newColumnId
 }
 
-async function getOrCreateFilesColumn({ accessToken, boardId, columnName = 'Files' }) {
+async function getOrCreateFilesColumn({ accessToken, boardId, columnName = 'Files', operation = 'getOrCreateFilesColumn' }) {
   let columnId = await getColumnIdByName({
     accessToken,
     boardId,
-    columnName
+    columnName,
+    operation
   })
 
   if (columnId) {
@@ -216,7 +267,8 @@ async function getOrCreateFilesColumn({ accessToken, boardId, columnName = 'File
     {
       boardId: Number(boardId),
       title: columnName
-    }
+    },
+    { operation }
   )
 
   if (!res?.data?.create_column?.id) {
@@ -231,7 +283,7 @@ async function getOrCreateFilesColumn({ accessToken, boardId, columnName = 'File
   return newColumnId
 }
 
-async function getColumnIdByName({ accessToken, boardId, columnName }) {
+async function getColumnIdByName({ accessToken, boardId, columnName, operation = 'getColumnIdByName' }) {
   if (!columnName) {
     return null
   }
@@ -258,7 +310,8 @@ async function getColumnIdByName({ accessToken, boardId, columnName }) {
       }
     }
     `,
-    { boardId: Number(boardId) }
+    { boardId: Number(boardId) },
+    { operation }
   )
   const boardData = res?.data?.boards?.[0]
   const columns = boardData?.columns || []
@@ -336,14 +389,15 @@ async function getOauthInfo() {
     clientSecret: process.env.MONDAY_CLIENT_SECRET,
     accessTokenUri: process.env.MONDAY_TOKEN_URI,
     redirectUri: process.env.REDIRECT_URI,
-    scopes: ['me:read', 'users:read', 'boards:read', 'boards:write', 'updates:write']
+    scopes: ['me:read', 'users:read', 'boards:read', 'boards:write', 'updates:write', 'account:read']
   };
 }
 
 async function getUserInfo({ authHeader, hostname, query }) {
+  console.log("Hostname : ", hostname)
   // OAuth callback already provides `query` with rcAccountId — no framework change needed.
   const rcAccountId = query?.rcAccountId;
-  console.log("Rc AccountId", rcAccountId)
+  apiLog.logStart('Monday', 'getUserInfo', { rcAccountId, hostname });
   try {
     const accessToken = authHeader.replace('Bearer ', '');
     if (!accessToken) {
@@ -353,23 +407,34 @@ async function getUserInfo({ authHeader, hostname, query }) {
       };
     }
 
-    console.log('[Monday][api] → query me (getUserInfo)');
-    const userDataResponse = await mondayApiClient.post(
-      MONDAY_API_URL,
-      { query: "query { me { id name email } }" },
-      {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-          "Content-Type": "application/json"
+    // Ask for account.slug too (the account the token was issued for). If the token lacks
+    // the scope for the account field, retry with the plain `me` query so connect never
+    // breaks — we just lose the slug and fall back to the extension-provided hostname.
+    const meQuery = async (query) => {
+      const response = await mondayApiClient.post(
+        MONDAY_API_URL,
+        { query },
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            "Content-Type": "application/json"
+          },
+          _operation: 'getUserInfo'
         }
-      }
-    );
+      );
+      return response.data;
+    };
 
-    const result = userDataResponse.data;
+    console.log('[Monday][api] → query me (getUserInfo)');
+    let result = await meQuery("query { me { id name email account { slug } } }");
+    if (result?.errors?.length || !result?.data?.me) {
+      console.warn('[Monday][getUserInfo] me query with account.slug failed — retrying without it', stringifyForLog(result?.errors, 800));
+      result = await meQuery("query { me { id name email } }");
+    }
     if (result?.errors?.length) {
       console.error('[Monday][api] ✗ GraphQL error (getUserInfo me)', stringifyForLog(result.errors, 800));
     } else {
-      console.log('[Monday][api] ← query me (getUserInfo)', { meId: result?.data?.me?.id });
+      console.log('[Monday][api] ← query me (getUserInfo)', { meId: result?.data?.me?.id, accountSlug: result?.data?.me?.account?.slug });
     }
     if (!result?.data?.me) {
       return {
@@ -389,11 +454,18 @@ async function getUserInfo({ authHeader, hostname, query }) {
       email: result.data.me.email
     };
 
-    // Normalize the hostname (admin may enter a full URL in the managed-OAuth form)
-    // so it is stored as a bare host — required for the license lookup and for the
-    // {hostname} URL templates to resolve correctly.
-    const cleanHostname = normalizeHostname(hostname);
-    console.log('[Monday][getUserInfo] hostname normalized', { rawHostname: hostname, cleanHostname });
+    // Derive the hostname from the account the token was ACTUALLY issued for (me.account.slug),
+    // not from what the extension passed in. The extension's dynamic-environment hostname is
+    // sticky (first workspace URL it saw) and auth.monday.com authorizes the user's active
+    // session account — both can disagree with the account the user meant to connect. The
+    // slug is authoritative: token, hostname and {hostname} URL templates always match.
+    const accountSlug = result?.data?.me?.account?.slug || null;
+    const slugHostname = accountSlug ? `${accountSlug}.monday.com` : null;
+    if (!slugHostname) {
+      console.warn('[Monday][getUserInfo] me.account.slug missing — falling back to extension-provided hostname', { rawHostname: hostname });
+    }
+    const cleanHostname = normalizeHostname(slugHostname || hostname);
+    console.log('[Monday][getUserInfo] hostname resolved', { accountSlug, rawHostname: hostname, cleanHostname });
 
     // Company / customer onboarding — mirrors the ServiceTitan pattern so that each
     // connecting user is registered in the `customer` table with a `companyId` FK.
@@ -410,6 +482,7 @@ async function getUserInfo({ authHeader, hostname, query }) {
             raw: true
           });
         }
+        console.log("Company: ", company)
         if (!company) {
           company = await models.companies.findOne({
             where: { rcAccountId: String(rcAccountId), status: true },
@@ -469,13 +542,14 @@ async function getUserInfo({ authHeader, hostname, query }) {
     // rest of the system reuses it without re-discovering.
     let boardId = null;
     try {
-      const boards = await getCrmBoards({ accessToken, userId: null });
+      const boards = await getCrmBoards({ accessToken, userId: null, operation: 'getUserInfo' });
       boardId = pickDefaultBoard(boards)?.id || null;
       console.log('[Monday][getUserInfo] selected board', { boardId, discoveredBoardCount: boards.length });
     } catch (e) {
       console.warn('[Monday][getUserInfo] board discovery failed (will retry lazily):', e.message);
     }
 
+    apiLog.logSuccess('Monday', 'getUserInfo', { userId: userData.id, boardId, hostname: cleanHostname });
     return {
       successful: true,
       platformUserInfo: {
@@ -518,7 +592,7 @@ async function unAuthorize({ user }) {
 
 // Discover the CRM boards a connected user can access — any active board that has a
 // Phone column. Results are cached briefly per user to avoid repeated board lookups.
-async function getCrmBoards({ accessToken, userId }) {
+async function getCrmBoards({ accessToken, userId, operation = 'getCrmBoards' }) {
   const now = Date.now();
   const cached = userId ? boardCache.get(userId) : null;
   if (cached && cached.expiry > now) {
@@ -535,7 +609,9 @@ async function getCrmBoards({ accessToken, userId }) {
         columns { id title type }
       }
     }
-    `
+    `,
+    {},
+    { operation }
   );
 
   const rawBoards = res?.data?.boards || [];
@@ -572,13 +648,13 @@ function getUserId(user) {
 // The connector uses a single board for everything. It is discovered once (the default
 // board with a Phone column), stored on the user record's platformAdditionalInfo, and
 // reused everywhere — no per-contact board lookup.
-async function getBoardId({ user, accessToken }) {
+async function getBoardId({ user, accessToken, operation = 'getBoardId' }) {
   const pai = user?.platformAdditionalInfo || user?.dataValues?.platformAdditionalInfo || {};
   if (pai.boardId) {
     return String(pai.boardId);
   }
   // Not stored yet — discover the default board and persist it on the user record.
-  const boards = await getCrmBoards({ accessToken, userId: getUserId(user) });
+  const boards = await getCrmBoards({ accessToken, userId: getUserId(user), operation });
   const board = pickDefaultBoard(boards);
   const boardId = board?.id || null;
   console.log('[Monday][board] discovered board', { boardId, boardName: board?.name, discoveredBoardCount: boards.length });
@@ -601,15 +677,15 @@ async function getBoardId({ user, accessToken }) {
 
 // Logging always targets the connector's single board (read stored, else discover).
 // This does not depend on contactInfo.type surviving the extension round-trip.
-async function resolveBoardId({ accessToken, user }) {
-  const boardId = await getBoardId({ user, accessToken });
-  console.log('[Monday][board] resolveBoardId ->', { boardId });
+async function resolveBoardId({ accessToken, user, operation = 'resolveBoardId' }) {
+  const boardId = await getBoardId({ user, accessToken, operation });
+  console.log('[Monday][board] resolveBoardId ->', { boardId, operation });
   return boardId;
 }
 
 // The Phone column id for a board, cached via getColumnIdByName.
-async function getPhoneColumnId({ accessToken, boardId }) {
-  return getColumnIdByName({ accessToken, boardId, columnName: 'Phone' });
+async function getPhoneColumnId({ accessToken, boardId, operation = 'getPhoneColumnId' }) {
+  return getColumnIdByName({ accessToken, boardId, columnName: 'Phone', operation });
 }
 
 function parseMondayCallLogBody(body = '') {
@@ -673,7 +749,7 @@ function parseMondayCallLogBody(body = '') {
   }
 }
 
-async function searchBoardByPhone({ accessToken, boardId, phoneColumnId, phone }) {
+async function searchBoardByPhone({ accessToken, boardId, phoneColumnId, phone, operation = 'findContact' }) {
   // Try formats in priority order (Monday's "+1 623 201 1816" first) and STOP at the
   // first format that matches — best case is a single query. Each request is bounded by
   // the client timeout and try/caught, so a slow/failed format is skipped, not fatal.
@@ -692,7 +768,8 @@ async function searchBoardByPhone({ accessToken, boardId, phoneColumnId, phone }
           }
         }
         `,
-        { value: searchValue }
+        { value: searchValue },
+        { operation }
       )
       if (res?.errors?.length) {
         console.warn('[Monday] searchBoardByPhone error on board', boardId, res.errors[0].message)
@@ -711,6 +788,7 @@ async function searchBoardByPhone({ accessToken, boardId, phoneColumnId, phone }
 }
 
 async function findContact({ phoneNumber, accessToken, authHeader, user, isExtension }) {
+  apiLog.logStart('Monday', 'findContact', { phoneNumber, isExtension });
   const licenseError = await validateLicenseOrFail(user, 'findContact');
   if (licenseError) return licenseError;
 
@@ -729,7 +807,7 @@ async function findContact({ phoneNumber, accessToken, authHeader, user, isExten
   // points the "open contact" / "view call log" links at that contact's actual board.
   let boards = []
   try {
-    boards = await getCrmBoards({ accessToken: resolvedAccessToken, userId: getUserId(user) })
+    boards = await getCrmBoards({ accessToken: resolvedAccessToken, userId: getUserId(user), operation: 'findContact' })
   } catch (e) {
     // A board-discovery failure (e.g. a slow query hitting the request timeout) should not
     // surface as a hard error — tell the user to retry.
@@ -746,9 +824,9 @@ async function findContact({ phoneNumber, accessToken, authHeader, user, isExten
   if (phone) {
     // Search each board's Phone column in parallel, tagging every match with its board id.
     const perBoardMatches = await Promise.all(boards.map(async board => {
-      const phoneColumnId = board.phoneColumnId || await getPhoneColumnId({ accessToken: resolvedAccessToken, boardId: board.id })
+      const phoneColumnId = board.phoneColumnId || await getPhoneColumnId({ accessToken: resolvedAccessToken, boardId: board.id, operation: 'findContact' })
       if (!phoneColumnId) return []
-      const items = await searchBoardByPhone({ accessToken: resolvedAccessToken, boardId: board.id, phoneColumnId, phone })
+      const items = await searchBoardByPhone({ accessToken: resolvedAccessToken, boardId: board.id, phoneColumnId, phone, operation: 'findContact' })
       // The extension reads `type` off the contact to build the RC entity's contactType
       // (contacts/match.js), which feeds the {contactType} URL variable. Set both names to be safe.
       return items.map(item => ({ id: item.id, name: item.name, phone, type: String(board.id), contactType: String(board.id), boardId: board.id }))
@@ -776,10 +854,12 @@ async function findContact({ phoneNumber, accessToken, authHeader, user, isExten
     isNewContact: true
   })
 
+  apiLog.logSuccess('Monday', 'findContact', { phoneNumber, matchedCount: matchedContactInfo.length - 1, boardsSearched: boards.length });
   return { successful: true, matchedContactInfo }
 }
 
 async function findContactWithName({ name, accessToken, authHeader, user }) {
+  apiLog.logStart('Monday', 'findContactWithName', { name });
   const licenseError = await validateLicenseOrFail(user, 'findContactWithName');
   if (licenseError) return licenseError;
 
@@ -794,7 +874,7 @@ async function findContactWithName({ name, accessToken, authHeader, user }) {
   // "Contact search by name failed". Degrade to an empty result instead.
   let boardId = null
   try {
-    boardId = await getBoardId({ user, accessToken: resolvedAccessToken })
+    boardId = await getBoardId({ user, accessToken: resolvedAccessToken, operation: 'findContactWithName' })
   } catch (e) {
     console.warn('[Monday] findContactWithName: board resolution failed', e.message)
     return { successful: true, matchedContactInfo: [] }
@@ -823,7 +903,8 @@ async function findContactWithName({ name, accessToken, authHeader, user }) {
         }
       }
       `,
-      { boardId: [boardId] }
+      { boardId: [boardId] },
+      { operation: 'findContactWithName' }
     )
     if (res?.errors?.length) {
       console.warn('[Monday] findContactWithName error on board', boardId, res.errors[0].message)
@@ -836,18 +917,19 @@ async function findContactWithName({ name, accessToken, authHeader, user }) {
 
   // `type` feeds the RC entity contactType (contacts/match.js) → {contactType} URL var.
   const matchedContactInfo = items.map(item => ({ id: item.id, name: item.name, type: String(boardId), contactType: String(boardId), boardId }))
-  console.log('[Monday] findContactWithName', { term, matches: matchedContactInfo.length })
+  apiLog.logSuccess('Monday', 'findContactWithName', { name: term, matchedCount: matchedContactInfo.length, boardId })
 
   return { successful: true, matchedContactInfo }
 }
 
 async function createContact({ phoneNumber, newContactName, accessToken, authHeader, user }) {
+  apiLog.logStart('Monday', 'createContact', { phoneNumber, newContactName });
   const licenseError = await validateLicenseOrFail(user, 'createContact');
   if (licenseError) return licenseError;
 
   const resolvedAccessToken = authHeader?.replace('Bearer ', '') || accessToken || user?.accessToken
-  const boardId = await getBoardId({ user, accessToken: resolvedAccessToken })
-  const phoneColumnId = boardId ? await getPhoneColumnId({ accessToken: resolvedAccessToken, boardId }) : null
+  const boardId = await getBoardId({ user, accessToken: resolvedAccessToken, operation: 'createContact' })
+  const phoneColumnId = boardId ? await getPhoneColumnId({ accessToken: resolvedAccessToken, boardId, operation: 'createContact' }) : null
   if (!boardId || !phoneColumnId) {
     return {
       contactInfo: null,
@@ -890,7 +972,8 @@ async function createContact({ phoneNumber, newContactName, accessToken, authHea
       {
         name: newContactName,
         values: JSON.stringify({ [phoneColumnId]: variant })
-      }
+      },
+      { operation: 'createContact' }
     )
     if (!res?.errors?.length && res?.data?.create_item?.id) {
       created = res.data.create_item
@@ -911,7 +994,7 @@ async function createContact({ phoneNumber, newContactName, accessToken, authHea
     }
   }
 
-  console.log('[Monday][createContact] created item', { itemId: created.id, boardId })
+  apiLog.logSuccess('Monday', 'createContact', { contactId: created.id, boardId })
 
   await trackAnalytics({ user, crm: 'Monday', event: 'contactCreated' });
 
@@ -949,6 +1032,7 @@ async function getMondayUserName(user) {
 }
 
 async function createCallLog({ contactInfo, callLog, note, aiNote, transcript, accessToken, authHeader, user }) {
+  apiLog.logStart('Monday', 'createCallLog', { contactId: contactInfo?.id, direction: callLog?.direction, duration: callLog?.duration, sessionId: callLog?.sessionId, hasRecording: !!callLog?.recording?.downloadUrl });
   const licenseError = await validateLicenseOrFail(user, 'createCallLog');
   if (licenseError) return licenseError;
 
@@ -977,7 +1061,7 @@ async function createCallLog({ contactInfo, callLog, note, aiNote, transcript, a
     sections.push(`Recording:<br>${callLog.recording.link}`)
   }
   if (aiNote && (user.userSettings?.addCallLogAiNote?.value ?? true)) {
-    sections.push(`AI Note:<br>${aiNote.replace(/\r?\n/g, '<br>')}`)
+    sections.push(`AI Note:<br>${stripMarkdownBold(aiNote).replace(/\r?\n/g, '<br>')}`)
   }
   if (transcript && (user.userSettings?.addCallLogTranscript?.value ?? true)) {
     sections.push(`Transcript:<br>${transcript.replace(/\r?\n/g, '<br>')}`)
@@ -1018,9 +1102,9 @@ async function createCallLog({ contactInfo, callLog, note, aiNote, transcript, a
 
   const footerLines = [];
   if (callLog.startTime && (user.userSettings?.addCallLogDateTime?.value ?? true)) {
-    footerLines.push(`Start Time: ${moment(callLog.startTime).format("YYYY-MM-DD HH:mm:ss")}`);
+    footerLines.push(`Start Time: ${formatDateTime({ user, time: callLog.startTime })}`);
     if (callLog.duration) {
-      footerLines.push(`End Time: ${moment(callLog.startTime).add(callLog.duration, "seconds").format("YYYY-MM-DD HH:mm:ss")}`);
+      footerLines.push(`End Time: ${formatDateTime({ user, time: moment(callLog.startTime).add(callLog.duration, "seconds") })}`);
     }
   }
 
@@ -1048,7 +1132,8 @@ async function createCallLog({ contactInfo, callLog, note, aiNote, transcript, a
     {
       itemId: Number(contactInfo.id),
       body
-    }
+    },
+    { operation: 'createCallLog' }
   )
   assertNoGraphqlErrors(res, `createCallLog (create_update itemId=${contactInfo.id})`)
 
@@ -1056,14 +1141,14 @@ async function createCallLog({ contactInfo, callLog, note, aiNote, transcript, a
   if (!updateId) {
     throw new Error(`Monday createCallLog: create_update returned no id for itemId=${contactInfo.id}`)
   }
-  console.log('[Monday][createCallLog] created update', { updateId, itemId: Number(contactInfo.id), boardId })
+  apiLog.logSuccess('Monday', 'createCallLog', { logId: updateId, contactId: Number(contactInfo.id), boardId })
 
   // ---- Recording Upload ----
   // Only here is the board id actually needed. Use the one carried on the contact; resolve
   // it lazily (one query) only if it wasn't provided, so the call log itself never blocks on
   // board discovery.
   if (callLog?.recording?.downloadUrl) {
-    const uploadBoardId = boardId || await resolveBoardId({ accessToken: resolvedAccessToken, user })
+    const uploadBoardId = boardId || await resolveBoardId({ accessToken: resolvedAccessToken, user, operation: 'createCallLog' })
     const fileName = `Call-${Date.now()}.mp3`
     const s3Key = fileName
     const s3Url = await downloadAudioFile(
@@ -1072,13 +1157,15 @@ async function createCallLog({ contactInfo, callLog, note, aiNote, transcript, a
       s3Key
     )
 
-    await uploadToMonday({
-      s3Url,
-      accessToken: resolvedAccessToken,
-      itemId: Number(contactInfo.id),
-      fileName,
-      boardId: uploadBoardId
-    })
+    if (s3Url) {
+      await uploadToMonday({
+        s3Url,
+        accessToken: resolvedAccessToken,
+        itemId: Number(contactInfo.id),
+        fileName,
+        boardId: uploadBoardId
+      })
+    }
   }
 
   await trackAnalytics({ user, crm: 'Monday', event: 'callLogCreated', eventDate: callLog?.startTime });
@@ -1094,7 +1181,29 @@ async function createCallLog({ contactInfo, callLog, note, aiNote, transcript, a
   }
 }
 
-async function updateCallLog({ existingCallLog, recordingLink, note, aiNote, transcript, accessToken, authHeader, user, subject, duration, startTime, result }) {
+// Mirror createCallLog's recording upload for updates: the recording usually arrives AFTER
+// the log is created (recording-sync fires updateCallLog), so attach the audio file to the
+// contact item's Files column here too. Failures are logged but never break the log update.
+// `recordingLink` here should be the DOWNLOAD link (tokenized) when available — the
+// media-reader page link often has no accessToken, so downloading it fails auth.
+async function uploadCallRecording({ accessToken, user, itemId, recordingLink, operation = 'updateCallLog' }) {
+  if (!recordingLink || !itemId) return
+  try {
+    const boardId = await resolveBoardId({ accessToken, user, operation })
+    const fileName = `Call-${Date.now()}.mp3`
+    const s3Url = await downloadAudioFile(recordingLink, process.env.S3_BUCKET, fileName)
+    if (!s3Url) {
+      console.warn(`[Monday][${operation}] recording download failed — skipping file upload`, { itemId })
+      return
+    }
+    await uploadToMonday({ s3Url, accessToken, itemId: Number(itemId), fileName, boardId })
+    console.log(`[Monday][${operation}] recording file attached`, { itemId, boardId })
+  } catch (e) {
+    console.warn(`[Monday][${operation}] recording upload failed`, { itemId, message: e.message })
+  }
+}
+
+async function updateCallLog({ existingCallLog, recordingLink, recordingDownloadLink, note, aiNote, transcript, accessToken, authHeader, user, subject, duration, startTime, result }) {
   const licenseError = await validateLicenseOrFail(user, 'updateCallLog');
   if (licenseError) return licenseError;
 
@@ -1102,10 +1211,12 @@ async function updateCallLog({ existingCallLog, recordingLink, note, aiNote, tra
     authHeader?.replace('Bearer ', '') || accessToken || user?.accessToken
   const logId = existingCallLog?.thirdPartyLogId
   const itemId = Number(existingCallLog?.contactId)
-  console.log('[Monday][updateCallLog] start', {
-    thirdPartyLogId: logId,
+  apiLog.logStart('Monday', 'updateCallLog', {
+    logId,
     contactId: existingCallLog?.contactId,
-    isNumericId: isNumericMondayId(logId)
+    isNumericId: isNumericMondayId(logId),
+    hasRecordingLink: !!recordingLink,
+    hasRecordingDownloadLink: !!recordingDownloadLink
   })
 
   // 1. Read the existing update so we can merge with it — only if the stored id is a
@@ -1124,7 +1235,8 @@ async function updateCallLog({ existingCallLog, recordingLink, note, aiNote, tra
           }
         }
         `,
-        { updateId: [logId] }
+        { updateId: [logId] },
+        { operation: 'updateCallLog' }
       )
       if (res?.errors?.length) {
         console.warn('[Monday][updateCallLog] could not read existing update; will recreate', { logId })
@@ -1175,7 +1287,7 @@ async function updateCallLog({ existingCallLog, recordingLink, note, aiNote, tra
     sections.push(`Recording:<br>${effectiveRecording}`)
   }
   if (effectiveAiNote && (user.userSettings?.addCallLogAiNote?.value ?? true)) {
-    sections.push(`AI Note:<br>${effectiveAiNote.replace(/\r?\n/g, '<br>')}`)
+    sections.push(`AI Note:<br>${stripMarkdownBold(effectiveAiNote).replace(/\r?\n/g, '<br>')}`)
   }
   if (effectiveTranscript && (user.userSettings?.addCallLogTranscript?.value ?? true)) {
     sections.push(`Transcript:<br>${effectiveTranscript.replace(/\r?\n/g, '<br>')}`)
@@ -1185,9 +1297,9 @@ async function updateCallLog({ existingCallLog, recordingLink, note, aiNote, tra
   let endTimeToUse = parsed.endTime
 
   if (startTime) {
-    startTimeToUse = moment(startTime).format("YYYY-MM-DD HH:mm:ss")
+    startTimeToUse = formatDateTime({ user, time: startTime })
     if (duration) {
-      endTimeToUse = moment(startTime).add(duration, "seconds").format("YYYY-MM-DD HH:mm:ss")
+      endTimeToUse = formatDateTime({ user, time: moment(startTime).add(duration, "seconds") })
     }
   }
 
@@ -1251,9 +1363,17 @@ async function updateCallLog({ existingCallLog, recordingLink, note, aiNote, tra
           }
         }
         `,
-        { updateId: logId, body }
+        { updateId: logId, body },
+        { operation: 'updateCallLog' }
       )
       if (!updateRes?.errors?.length && updateRes?.data?.edit_update?.id) {
+        // Attach the recording file only when a NEW recording link arrived (the old body not
+        // already carrying it) — otherwise every later edit would re-upload a duplicate file.
+        // Prefer the tokenized download link; the display link is the fallback.
+        if (recordingLink && recordingLink !== parsed.recording) {
+          await uploadCallRecording({ accessToken: resolvedAccessToken, user, itemId, recordingLink: recordingDownloadLink || recordingLink })
+        }
+        apiLog.logSuccess('Monday', 'updateCallLog', { logId: updateRes.data.edit_update.id, contactId: existingCallLog?.contactId, mode: 'edited' });
         await trackAnalytics({ user, crm: 'Monday', event: 'callLogUpdated', eventDate: startTime });
         return {
           logId: updateRes.data.edit_update.id,
@@ -1280,14 +1400,18 @@ async function updateCallLog({ existingCallLog, recordingLink, note, aiNote, tra
       }
     }
     `,
-    { itemId, body }
+    { itemId, body },
+    { operation: 'updateCallLog' }
   )
   assertNoGraphqlErrors(createRes, 'updateCallLog (create_update fallback)')
   const newLogId = createRes?.data?.create_update?.id
   if (!newLogId) {
     throw new Error('Monday updateCallLog: fallback create_update returned no id')
   }
-  console.log('[Monday][updateCallLog] recreated update', { oldLogId: logId, newLogId, itemId })
+  apiLog.logSuccess('Monday', 'updateCallLog', { logId: newLogId, oldLogId: logId, contactId: itemId, mode: 'recreated' })
+  if (recordingLink && recordingLink !== parsed.recording) {
+    await uploadCallRecording({ accessToken: resolvedAccessToken, user, itemId, recordingLink: recordingDownloadLink || recordingLink })
+  }
   // Repoint the stored id so the next update edits this new update instead of recreating.
   try {
     if (typeof existingCallLog?.update === 'function') {
@@ -1306,6 +1430,7 @@ async function updateCallLog({ existingCallLog, recordingLink, note, aiNote, tra
 }
 
 async function getCallLog({ callLogId, accessToken, authHeader, user }) {
+  apiLog.logStart('Monday', 'getCallLog', { logId: callLogId });
   const licenseError = await validateLicenseOrFail(user, 'getCallLog');
   if (licenseError) return licenseError;
 
@@ -1332,7 +1457,8 @@ async function getCallLog({ callLogId, accessToken, authHeader, user }) {
       }
     }
     `,
-    { updateId: [callLogId] }
+    { updateId: [callLogId] },
+    { operation: 'getCallLog' }
   )
 
   if (res?.errors?.length || !res?.data?.updates?.length) {
@@ -1354,6 +1480,7 @@ async function getCallLog({ callLogId, accessToken, authHeader, user }) {
   const rawBody = update.body || ''
   const parsed = parseMondayCallLogBody(rawBody)
 
+  apiLog.logSuccess('Monday', 'getCallLog', { logId: callLogId })
   return {
     callLogInfo: {
       subject: parsed.subject,
@@ -1373,17 +1500,19 @@ async function upsertCallDisposition({ existingCallLog }) {
   return { logId: existingCallLog.thirdPartyLogId }
 }
 
-async function createMessageLog({ user, contactInfo, message, recordingLink, faxDocLink, accessToken }) {
+async function createMessageLog({ user, contactInfo, message, recordingLink, recordingDownloadLink, faxDocLink, faxDownloadLink, accessToken }) {
+  apiLog.logStart('Monday', 'createMessageLog', { contactId: contactInfo?.id, direction: message?.direction, hasRecording: !!recordingLink, hasRecordingDownloadLink: !!recordingDownloadLink, hasFax: !!faxDocLink });
   const licenseError = await validateLicenseOrFail(user, 'createMessageLog');
   if (licenseError) return licenseError;
 
   const resolvedAccessToken = accessToken || user?.accessToken
-  const boardId = await resolveBoardId({ accessToken: resolvedAccessToken, user });
+  const boardId = await resolveBoardId({ accessToken: resolvedAccessToken, user, operation: 'createMessageLog' });
   const itemId = Number(contactInfo.id)
   const callLogsColumnId = await getOrCreateCallLogsColumn({
     accessToken: resolvedAccessToken,
     boardId,
-    columnName: 'Call Logs'
+    columnName: 'Call Logs',
+    operation: 'createMessageLog'
   })
   const messageType =
     recordingLink ? 'Voicemail' : (faxDocLink ? 'Fax' : 'SMS')
@@ -1396,7 +1525,7 @@ async function createMessageLog({ user, contactInfo, message, recordingLink, fax
         : 'You'
     const text = message.subject || message.text || ''
     body = `SMS conversation with ${contactInfo.name}<br>`
-    body += `[${moment(message.creationTime || Date.now()).format('YYYY-MM-DD HH:mm:ss')}] ${sender}: ${text}<br>`
+    body += `[${formatDateTime({ user, time: message.creationTime || Date.now() })}] ${sender}: ${text}<br>`
 
   }
 
@@ -1420,7 +1549,8 @@ async function createMessageLog({ user, contactInfo, message, recordingLink, fax
     {
       itemId,
       body
-    }
+    },
+    { operation: 'createMessageLog' }
   )
 
   if (!res?.data?.create_update?.id) {
@@ -1449,12 +1579,15 @@ async function createMessageLog({ user, contactInfo, message, recordingLink, fax
         itemId,
         columnId: callLogsColumnId,
         value: body
-      }
+      },
+      { operation: 'createMessageLog' }
     )
   }
 
   if (recordingLink || faxDocLink) {
-    const downloadUrl = recordingLink || faxDocLink
+    // Prefer the tokenized download links — the display links (media-reader pages)
+    // have no access token and 401 when downloaded server-side.
+    const downloadUrl = recordingDownloadLink || faxDownloadLink || getVoicemailDownloadLink(message) || recordingLink || faxDocLink
     const fileName =
       recordingLink
         ? `Voicemail-${Date.now()}.mp3`
@@ -1466,17 +1599,20 @@ async function createMessageLog({ user, contactInfo, message, recordingLink, fax
       s3Key
     )
 
-    await uploadToMonday({
-      s3Url,
-      accessToken: resolvedAccessToken,
-      itemId,
-      fileName,
-      boardId
-    })
+    if (s3Url) {
+      await uploadToMonday({
+        s3Url,
+        accessToken: resolvedAccessToken,
+        itemId,
+        fileName,
+        boardId
+      })
+    }
   }
 
   await trackAnalytics({ user, crm: 'Monday', event: 'messageLogCreated', eventDate: message?.creationTime });
 
+  apiLog.logSuccess('Monday', 'createMessageLog', { logId: updateId, contactId: itemId, messageType, boardId })
   return {
     logId: updateId,
     contactId: itemId,
@@ -1488,19 +1624,21 @@ async function createMessageLog({ user, contactInfo, message, recordingLink, fax
   }
 }
 
-async function updateMessageLog({ user, contactInfo, existingMessageLog, message, recordingLink, faxDocLink, accessToken }) {
+async function updateMessageLog({ user, contactInfo, existingMessageLog, message, recordingLink, recordingDownloadLink, faxDocLink, faxDownloadLink, accessToken }) {
+  apiLog.logStart('Monday', 'updateMessageLog', { contactId: contactInfo?.id, logId: existingMessageLog?.thirdPartyLogId, direction: message?.direction, hasRecording: !!recordingLink, hasFax: !!faxDocLink });
   const licenseError = await validateLicenseOrFail(user, 'updateMessageLog');
   if (licenseError) return licenseError;
 
   const MAX_THREAD_MESSAGES = 10
   const resolvedAccessToken = accessToken || user?.accessToken
-  const boardId = await resolveBoardId({ accessToken: resolvedAccessToken, user });
+  const boardId = await resolveBoardId({ accessToken: resolvedAccessToken, user, operation: 'updateMessageLog' });
   const itemId = Number(contactInfo.id)
   const updateId = existingMessageLog.thirdPartyLogId
   const callLogsColumnId = await getOrCreateCallLogsColumn({
     accessToken: resolvedAccessToken,
     boardId,
-    columnName: 'Call Logs'
+    columnName: 'Call Logs',
+    operation: 'updateMessageLog'
   })
   const messageType =
     recordingLink ? 'Voicemail' : (faxDocLink ? 'Fax' : 'SMS')
@@ -1531,13 +1669,15 @@ async function updateMessageLog({ user, contactInfo, existingMessageLog, message
       {
         itemId,
         body
-      }
+      },
+      { operation: 'updateMessageLog' }
     )
 
     const newUpdateId = res.data.create_update.id
 
     await trackAnalytics({ user, crm: 'Monday', event: 'messageLogUpdated', eventDate: message?.creationTime });
 
+    apiLog.logSuccess('Monday', 'updateMessageLog', { logId: newUpdateId, contactId: itemId, messageType })
     return {
       logId: newUpdateId,
       returnMessage: {
@@ -1562,7 +1702,8 @@ async function updateMessageLog({ user, contactInfo, existingMessageLog, message
       }
     }
     `,
-    { updateId: [updateId] }
+    { updateId: [updateId] },
+    { operation: 'updateMessageLog' }
   )
 
   const previousBody =
@@ -1572,8 +1713,10 @@ async function updateMessageLog({ user, contactInfo, existingMessageLog, message
       ? contactInfo.name
       : 'You'
   const text = message.subject || message.text || ''
-  const newLine =
-    `<br>[${moment(message.creationTime || Date.now()).format('YYYY-MM-DD HH:mm:ss')}] ${sender}: ${text}<br>`
+  // No leading/trailing <br> on the message line itself — junction breaks are added
+  // explicitly below, so messages are separated by exactly ONE line break (the old
+  // `<br>…<br>` pattern doubled up into a blank line between every message).
+  const newLine = `[${formatDateTime({ user, time: message.creationTime || Date.now() })}] ${sender}: ${text}`
   const messageLines =
     previousBody
       .split('<br>')
@@ -1582,44 +1725,77 @@ async function updateMessageLog({ user, contactInfo, existingMessageLog, message
   let updatedBody
   let response
   let newThreadId = updateId
+  // On a thread reset (>= MAX messages) the old update stays as history; otherwise the
+  // new update carries the merged history forward and the old one is deleted.
+  let shouldDeleteOld = false
 
   if (messageCount >= MAX_THREAD_MESSAGES) {
     updatedBody =
-      `SMS conversation with ${contactInfo.name}<br>` +
-      `[${moment(message.creationTime || Date.now()).format('YYYY-MM-DD HH:mm:ss')}] ${sender}: ${text}<br>`
-    response = await mondayRequest(
-      resolvedAccessToken,
-      `
-      mutation ($itemId: ID!, $body: String!) {
-        create_update(item_id: $itemId, body: $body) {
-          id
-        }
-      }
-      `,
-      {
-        itemId,
-        body: updatedBody
-      }
-    )
-
-    newThreadId = response.data.create_update.id
-
+      `SMS conversation with ${contactInfo.name}<br>${newLine}`
   } else {
-    updatedBody = previousBody + newLine
-    response = await mondayRequest(
-      resolvedAccessToken,
-      `
-      mutation ($updateId: ID!, $body: String!) {
-        edit_update(id: $updateId, body: $body) {
-          id
+    shouldDeleteOld = true
+    // Collapse legacy double breaks, then strip trailing breaks so the append adds
+    // exactly one line break — this also cleans up old threads on their next message.
+    const trimmedPrevious = previousBody
+      .replace(/(<br\s*\/?>)\s*(<br\s*\/?>)+/gi, '$1')
+      .replace(/(?:\s|<br\s*\/?>)+$/i, '')
+    updatedBody = trimmedPrevious
+      ? `${trimmedPrevious}<br>${newLine}`
+      : `SMS conversation with ${contactInfo.name}<br>${newLine}`
+  }
+
+  // Monday's updates feed is ordered by creation time and edit_update does NOT move an
+  // update up — so an ongoing conversation stayed buried under newer updates. Recreate
+  // the thread (create a fresh update with the full history, then delete the old one)
+  // so the conversation always surfaces on top.
+  response = await mondayRequest(
+    resolvedAccessToken,
+    `
+    mutation ($itemId: ID!, $body: String!) {
+      create_update(item_id: $itemId, body: $body) {
+        id
+      }
+    }
+    `,
+    {
+      itemId,
+      body: updatedBody
+    },
+    { operation: 'updateMessageLog' }
+  )
+  assertNoGraphqlErrors(response, 'updateMessageLog (create_update SMS thread)')
+  newThreadId = response?.data?.create_update?.id
+  if (!newThreadId) {
+    throw new Error('Monday updateMessageLog: create_update returned no id')
+  }
+
+  if (shouldDeleteOld && isNumericMondayId(updateId) && String(newThreadId) !== String(updateId)) {
+    try {
+      await mondayRequest(
+        resolvedAccessToken,
+        `
+        mutation ($updateId: ID!) {
+          delete_update(id: $updateId) {
+            id
+          }
         }
-      }
-      `,
-      {
-        updateId,
-        body: updatedBody
-      }
-    )
+        `,
+        { updateId },
+        { operation: 'updateMessageLog' }
+      )
+    } catch (e) {
+      console.warn('[Monday][updateMessageLog] failed to delete old thread update — a duplicate may remain', { oldUpdateId: updateId, message: e.message })
+    }
+  }
+
+  // Repoint the stored id so the next message appends to the recreated thread instead
+  // of a deleted update (which would restart the conversation and lose history).
+  if (String(newThreadId) !== String(updateId) && typeof existingMessageLog?.update === 'function') {
+    try {
+      await existingMessageLog.update({ thirdPartyLogId: String(newThreadId) })
+    } catch (e) {
+      console.warn('[Monday][updateMessageLog] failed to repoint thirdPartyLogId', { newThreadId, message: e.message })
+    }
   }
 
   if (callLogsColumnId) {
@@ -1642,12 +1818,15 @@ async function updateMessageLog({ user, contactInfo, existingMessageLog, message
         itemId,
         columnId: callLogsColumnId,
         value: updatedBody
-      }
+      },
+      { operation: 'updateMessageLog' }
     )
   }
 
   if (recordingLink || faxDocLink) {
-    const downloadUrl = recordingLink || faxDocLink
+    // Prefer the tokenized download links — the display links (media-reader pages)
+    // have no access token and 401 when downloaded server-side.
+    const downloadUrl = recordingDownloadLink || faxDownloadLink || getVoicemailDownloadLink(message) || recordingLink || faxDocLink
     const fileName =
       recordingLink
         ? `Voicemail-${Date.now()}.mp3`
@@ -1659,17 +1838,20 @@ async function updateMessageLog({ user, contactInfo, existingMessageLog, message
       s3Key
     )
 
-    await uploadToMonday({
-      s3Url,
-      accessToken: resolvedAccessToken,
-      itemId,
-      fileName,
-      boardId
-    })
+    if (s3Url) {
+      await uploadToMonday({
+        s3Url,
+        accessToken: resolvedAccessToken,
+        itemId,
+        fileName,
+        boardId
+      })
+    }
   }
 
   await trackAnalytics({ user, crm: 'Monday', event: 'messageLogUpdated', eventDate: message?.creationTime });
 
+  apiLog.logSuccess('Monday', 'updateMessageLog', { logId: newThreadId, contactId: itemId, messageType: 'SMS', appended: newThreadId === updateId })
   return {
     logId: newThreadId,
     returnMessage: {
@@ -1688,8 +1870,11 @@ async function getUserList() {
 }
 
 async function downloadAudioFile(url, s3Bucket, s3Key) {
+  // Unwrap media-reader page links to the raw media content URL (see resolveMediaContentUrl).
+  url = resolveMediaContentUrl(url);
   const urlObj = new URL(url);
-  const accessToken = urlObj.searchParams.get("accessToken");
+  // RC media links carry the token as either `accessToken` or `access_token`.
+  const accessToken = urlObj.searchParams.get("accessToken") || urlObj.searchParams.get("access_token");
   const s3Values = {
     accessKeyId: process.env.MEDIA_UPLOAD_KEY_ID,
     secretAccessKey: process.env.MEDIA_UPLOAD_SECRET_KEY,
@@ -1699,12 +1884,20 @@ async function downloadAudioFile(url, s3Bucket, s3Key) {
   console.log("Downloading Audio File...");
 
   try {
+    // Only send Authorization when we actually have a token — `Bearer null` makes RC
+    // reject the request even when the URL itself carries a valid query token.
     const response = await mondayApiClient.get(url, {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
+      headers: accessToken ? { Authorization: `Bearer ${accessToken}` } : {},
       responseType: "stream",
+      _operation: 'downloadAudioFile'
     });
+    // If we still got a web page instead of media, don't upload it — a .htm file in the
+    // Files column is worse than no file.
+    const contentType = response.headers?.['content-type'] || '';
+    if (contentType.includes('text/html')) {
+      console.warn('[Monday][downloadAudioFile] got HTML instead of media — skipping upload', { url: url.split('?')[0], contentType });
+      return null;
+    }
     const uploadParams = {
       Bucket: s3Bucket,
       Key: s3Key,
@@ -1724,7 +1917,8 @@ async function uploadToMonday({ s3Url, accessToken, itemId, fileName, boardId })
     console.log('[Monday][api] → file upload (add_file_to_column)', { itemId, boardId, fileName })
     const filesColumnId = await getOrCreateFilesColumn({
       accessToken,
-      boardId
+      boardId,
+      operation: 'uploadToMonday'
     })
 
     if (!filesColumnId) {
@@ -1752,7 +1946,7 @@ async function uploadToMonday({ s3Url, accessToken, itemId, fileName, boardId })
 
     formData.append('variables[file]', fileStream, {
       filename: fileName,
-      contentType: 'audio/mpeg'
+      contentType: fileName.toLowerCase().endsWith('.pdf') ? 'application/pdf' : 'audio/mpeg'
     })
 
     const response = await mondayApiClient.post(
@@ -1763,7 +1957,8 @@ async function uploadToMonday({ s3Url, accessToken, itemId, fileName, boardId })
           Authorization: `Bearer ${accessToken}`,
           ...formData.getHeaders()
         },
-        maxBodyLength: Infinity
+        maxBodyLength: Infinity,
+        _operation: 'uploadToMonday'
       }
     )
 

--- a/src/connectors/monday/index.ts
+++ b/src/connectors/monday/index.ts
@@ -131,7 +131,16 @@ function hasTransientMondayError(errors) {
 
 // `operation` names the connector function making the call (e.g. 'createCallLog') so every
 // API log line is attributable — same idea as ServiceTitan's `_operation` axios tag.
+//
+// Error contract: transient failures (HTTP 5xx / timeout / network, or Monday's
+// INTERNAL_SERVER_ERROR GraphQL errors) are retried up to `maxAttempts`. Once retries are
+// exhausted, HTTP/transport errors are re-thrown to the caller; GraphQL errors are returned
+// in the body (Monday sends them with HTTP 200) — callers that require data must check
+// `res.errors` or use assertNoGraphqlErrors.
 async function mondayRequest(accessToken, query, variables = {}, { maxAttempts = 2, operation = 'unknown' } = {}) {
+  if (!MONDAY_API_URL) {
+    throw new Error('MONDAY_API_URL is not configured on the server');
+  }
   const reqId = ++mondayApiCallCounter;
   const op = describeGraphqlOperation(query);
   let lastBody = null;
@@ -196,6 +205,9 @@ function isNumericMondayId(id) {
   return id != null && /^\d+$/.test(String(id));
 }
 
+// Resolve the board's "Call Logs" long-text column id, creating the column if it does
+// not exist yet. The id is cached per board+name; throws with the Monday GraphQL error
+// message when the column can be neither found nor created.
 async function getOrCreateCallLogsColumn({ accessToken, boardId, columnName = 'Call Logs', operation = 'getOrCreateCallLogsColumn' }) {
   let columnId = await getColumnIdByName({
     accessToken,
@@ -228,8 +240,9 @@ async function getOrCreateCallLogsColumn({ accessToken, boardId, columnName = 'C
     { operation }
   )
 
+  assertNoGraphqlErrors(res, `create "${columnName}" column`)
   if (!res?.data?.create_column?.id) {
-    throw new Error('Failed to create "Call Logs" column in Monday')
+    throw new Error(`Failed to create "${columnName}" column in Monday`)
   }
 
   const newColumnId = res.data.create_column.id
@@ -271,8 +284,9 @@ async function getOrCreateFilesColumn({ accessToken, boardId, columnName = 'File
     { operation }
   )
 
+  assertNoGraphqlErrors(res, `create "${columnName}" column`)
   if (!res?.data?.create_column?.id) {
-    throw new Error('Failed to create "Files" column in Monday')
+    throw new Error(`Failed to create "${columnName}" column in Monday`)
   }
 
   const newColumnId = res.data.create_column.id
@@ -758,16 +772,16 @@ async function searchBoardByPhone({ accessToken, boardId, phoneColumnId, phone, 
       const res = await mondayRequest(
         accessToken,
         `
-        query ($value: String!) {
+        query ($boardId: ID!, $columnId: String!, $value: String!) {
           items_page_by_column_values(
-            board_id: ${boardId},
-            columns: [{ column_id: "${phoneColumnId}", column_values: [$value] }]
+            board_id: $boardId,
+            columns: [{ column_id: $columnId, column_values: [$value] }]
           ) {
             items { id name }
           }
         }
         `,
-        { value: searchValue },
+        { boardId: String(boardId), columnId: String(phoneColumnId), value: searchValue },
         { operation }
       )
       if (res?.errors?.length) {

--- a/src/connectors/monday/index.ts
+++ b/src/connectors/monday/index.ts
@@ -541,13 +541,10 @@ async function getUserInfo({ authHeader, hostname, query }) {
     // Discover the connector's single board once, at connect time, and store it so the
     // rest of the system reuses it without re-discovering.
     let boardId = null;
-    let boardName = null;
     try {
       const boards = await getCrmBoards({ accessToken, userId: null, operation: 'getUserInfo' });
-      const defaultBoard = pickDefaultBoard(boards);
-      boardId = defaultBoard?.id || null;
-      boardName = defaultBoard?.name || null;
-      console.log('[Monday][getUserInfo] selected board', { boardId, boardName, discoveredBoardCount: boards.length });
+      boardId = pickDefaultBoard(boards)?.id || null;
+      console.log('[Monday][getUserInfo] selected board', { boardId, discoveredBoardCount: boards.length });
     } catch (e) {
       console.warn('[Monday][getUserInfo] board discovery failed (will retry lazily):', e.message);
     }
@@ -561,7 +558,7 @@ async function getUserInfo({ authHeader, hostname, query }) {
         email: userData.email,
         overridingApiKey: accessToken,
         ...(cleanHostname ? { overridingHostname: cleanHostname } : {}),
-        platformAdditionalInfo: { ...(boardId ? { boardId, boardName } : {}) }
+        platformAdditionalInfo: { ...(boardId ? { boardId } : {}) }
       },
       returnMessage: { messageType: 'success', message: 'Successfully connected to Monday.', ttl: 3000 }
     };
@@ -573,33 +570,6 @@ async function getUserInfo({ authHeader, hostname, query }) {
       returnMessage: { messageType: 'error', message: 'Monday authentication failed.', ttl: 3000 }
     };
   }
-}
-
-// Runs right after the user record is saved during OAuth connect (before the extension
-// fetches user settings). Seed the contactBoardId setting here — the framework hardcodes
-// `userSettings: {}` on create, so this is the earliest point we can populate it. Seeding at
-// connect (rather than lazily in findContact/getBoardId) ensures the {contactBoardId} URL
-// token resolves on the very first call-pop without the user opening Settings to enter it.
-async function postSaveUserInfo({ userInfo, oauthApp }) {
-  try {
-    // saveUserInfo returns only { id, name } — NOT the Sequelize instance — so re-fetch the
-    // persisted user to read platformAdditionalInfo.boardId (stored by getUserInfo at connect)
-    // and write userSettings.contactBoardId before the extension loads settings.
-    const userId = userInfo?.id;
-    if (userId) {
-      const user = await UserModel.findByPk(userId);
-      const pai = user?.platformAdditionalInfo || user?.dataValues?.platformAdditionalInfo || {};
-      if (user && pai.boardId) {
-        await seedContactBoardIdSetting(user, String(pai.boardId));
-        console.log('[Monday][postSaveUserInfo] seeded contactBoardId at connect', { userId, boardId: pai.boardId });
-      } else {
-        console.warn('[Monday][postSaveUserInfo] no boardId on user record; contactBoardId not seeded', { userId, hasUser: !!user });
-      }
-    }
-  } catch (e: any) {
-    console.warn('[Monday][postSaveUserInfo] failed to seed contactBoardId:', e.message);
-  }
-  return userInfo;
 }
 
 async function unAuthorize({ user }) {
@@ -678,43 +648,9 @@ function getUserId(user) {
 // The connector uses a single board for everything. It is discovered once (the default
 // board with a Phone column), stored on the user record's platformAdditionalInfo, and
 // reused everywhere — no per-contact board lookup.
-// Self-labeling display value for a matched/created contact's `type`/`contactType`. Renders
-// as e.g. "Board: Sales Leads" so the board name is distinguishable from the numeric Monday
-// item (pulse) id shown alongside it. Falls back to the board id when the name is unknown
-// (e.g. users connected before boardName was persisted). Used only for display — the deep-link
-// URL resolves the board via the {contactBoardId} setting and logging reads the persisted id.
-function boardDisplayLabel({ boardName, boardId }: { boardName?: any, boardId?: any }) {
-  const val = boardName || (boardId != null ? String(boardId) : '');
-  return val ? `Board: ${val}` : '';
-}
-
-// Auto-populate the per-user `contactBoardId` setting so the {contactBoardId} URL token
-// (contactPageUrl/logPageUrl/callPopUrl) resolves without the admin entering it manually.
-// The token reads from `userSettings.contactBoardId.value`. Written only when it differs, to
-// avoid redundant DB writes. This also backfills users whose board was persisted before the
-// feature existed.
-async function seedContactBoardIdSetting(user: any, boardId: string) {
-  if (!boardId || typeof user?.update !== 'function') return;
-  const current = user.userSettings || user.dataValues?.userSettings || {};
-  if (String(current?.contactBoardId?.value ?? '') === String(boardId)) return;
-  try {
-    const nextSettings = { ...current, contactBoardId: { value: String(boardId) } };
-    await user.update({ userSettings: nextSettings });
-    if (typeof user.changed === 'function') {
-      user.changed('userSettings', true);
-      if (typeof user.save === 'function') await user.save();
-    }
-    console.log('[Monday][board] seeded contactBoardId setting', { boardId });
-  } catch (e: any) {
-    console.warn('[Monday][board] failed to seed contactBoardId setting:', e.message);
-  }
-}
-
 async function getBoardId({ user, accessToken, operation = 'getBoardId' }) {
   const pai = user?.platformAdditionalInfo || user?.dataValues?.platformAdditionalInfo || {};
   if (pai.boardId) {
-    // Backfill the contactBoardId setting for users whose board was persisted earlier.
-    await seedContactBoardIdSetting(user, String(pai.boardId));
     return String(pai.boardId);
   }
   // Not stored yet — discover the default board and persist it on the user record.
@@ -724,7 +660,7 @@ async function getBoardId({ user, accessToken, operation = 'getBoardId' }) {
   console.log('[Monday][board] discovered board', { boardId, boardName: board?.name, discoveredBoardCount: boards.length });
   if (boardId && typeof user?.update === 'function') {
     try {
-      const nextPai = { ...pai, boardId, boardName: board?.name || pai.boardName };
+      const nextPai = { ...pai, boardId };
       await user.update({ platformAdditionalInfo: nextPai });
       // JSON columns don't always auto-flag as changed; force a save to be safe.
       if (typeof user.changed === 'function') {
@@ -735,8 +671,6 @@ async function getBoardId({ user, accessToken, operation = 'getBoardId' }) {
     } catch (e) {
       console.warn('[Monday][board] failed to persist boardId on user record:', e.message);
     }
-    // Seed the contactBoardId setting so the {contactBoardId} URL token resolves.
-    await seedContactBoardIdSetting(user, String(boardId));
   }
   return boardId;
 }
@@ -867,48 +801,38 @@ async function findContact({ phoneNumber, accessToken, authHeader, user, isExten
   }
 
   const resolvedAccessToken = authHeader?.replace('Bearer ', '') || accessToken || user?.accessToken
-
-  // ── SINGLE-BOARD MODE ─────────────────────────────────────────────────────────────────
-  // Multi-board search is disabled for now. Contacts are matched against the connector's
-  // single default board. `boardId` is kept for logging; `type`/`contactType` now carry the
-  // board NAME (shown in the contact list) since the deep-link URL uses the {contactBoardId}
-  // setting token, not {contactType}. We also seed that setting from the resolved board.
-  //
-  // --- multi-board search (commented out; restore to search every board) ---
-  // let boards = []
-  // try { boards = await getCrmBoards({ accessToken: resolvedAccessToken, userId: getUserId(user) }) }
-  // catch (e) { return { successful: false, returnMessage: { messageType: 'warning', message: 'Monday is taking too long to respond. Please try again.', ttl: 3000 } } }
-  // const perBoardMatches = await Promise.all(boards.map(async board => { ... type: String(board.id) ... }))
-  // --------------------------------------------------------------------------
-  let board: any = null
+  // Contacts can live on ANY board, so search every accessible CRM board (each active board
+  // with a Phone column), not just the single default board. Each match is tagged with the id
+  // of the board it was found on, so `type`/`contactType` (the {contactType} URL variable)
+  // points the "open contact" / "view call log" links at that contact's actual board.
+  let boards = []
   try {
-    const boards = await getCrmBoards({ accessToken: resolvedAccessToken, userId: getUserId(user), operation: 'findContact' })
-    board = pickDefaultBoard(boards)
-  } catch (e: any) {
+    boards = await getCrmBoards({ accessToken: resolvedAccessToken, userId: getUserId(user), operation: 'findContact' })
+  } catch (e) {
     // A board-discovery failure (e.g. a slow query hitting the request timeout) should not
     // surface as a hard error — tell the user to retry.
     console.warn('[Monday] findContact: board discovery failed', e.message)
     return { successful: false, returnMessage: { messageType: 'warning', message: 'Monday is taking too long to respond. Please try again.', ttl: 3000 } }
   }
-  if (!board) {
+  if (!boards || boards.length === 0) {
     return { successful: false, returnMessage: { messageType: 'error', message: 'No Monday board with a Phone column was found. Add a Phone column to your board and try again.', ttl: 3000 } }
   }
-  // Auto-populate the contactBoardId setting so the {contactBoardId} URL token resolves.
-  await seedContactBoardIdSetting(user, String(board.id))
 
-  const boardName = board.name || String(board.id)
   const phone = normalizePhone(phoneNumber)
-  const matchedContactInfo: any[] = []
+  const matchedContactInfo = []
 
   if (phone) {
-    const phoneColumnId = board.phoneColumnId || await getPhoneColumnId({ accessToken: resolvedAccessToken, boardId: board.id })
-    if (phoneColumnId) {
-      const items = await searchBoardByPhone({ accessToken: resolvedAccessToken, boardId: board.id, phoneColumnId, phone })
-      const boardLabel = boardDisplayLabel({ boardName, boardId: board.id })
-      for (const item of items) {
-        // Display the board name (self-labeled "Board: …") in the contact list; keep boardId for logging.
-        matchedContactInfo.push({ id: item.id, name: item.name, phone, type: boardLabel, contactType: boardLabel, boardId: board.id, boardName })
-      }
+    // Search each board's Phone column in parallel, tagging every match with its board id.
+    const perBoardMatches = await Promise.all(boards.map(async board => {
+      const phoneColumnId = board.phoneColumnId || await getPhoneColumnId({ accessToken: resolvedAccessToken, boardId: board.id, operation: 'findContact' })
+      if (!phoneColumnId) return []
+      const items = await searchBoardByPhone({ accessToken: resolvedAccessToken, boardId: board.id, phoneColumnId, phone, operation: 'findContact' })
+      // The extension reads `type` off the contact to build the RC entity's contactType
+      // (contacts/match.js), which feeds the {contactType} URL variable. Set both names to be safe.
+      return items.map(item => ({ id: item.id, name: item.name, phone, type: String(board.id), contactType: String(board.id), boardId: board.id }))
+    }))
+    for (const boardMatches of perBoardMatches) {
+      matchedContactInfo.push(...boardMatches)
     }
 
     if (matchedContactInfo.length === 0 && user?.rcAccountId) {
@@ -992,11 +916,8 @@ async function findContactWithName({ name, accessToken, authHeader, user }) {
   }
 
   // `type` feeds the RC entity contactType (contacts/match.js) → {contactType} URL var.
-  // Match findContact's display: board name (self-labeled), not the raw boardId.
-  const wnPai = user?.platformAdditionalInfo || user?.dataValues?.platformAdditionalInfo || {}
-  const wnBoardLabel = boardDisplayLabel({ boardName: wnPai.boardName, boardId })
-  const matchedContactInfo = items.map(item => ({ id: item.id, name: item.name, type: wnBoardLabel, contactType: wnBoardLabel, boardId, boardName: wnPai.boardName }))
-  console.log('[Monday] findContactWithName', { term, matches: matchedContactInfo.length })
+  const matchedContactInfo = items.map(item => ({ id: item.id, name: item.name, type: String(boardId), contactType: String(boardId), boardId }))
+  apiLog.logSuccess('Monday', 'findContactWithName', { name: term, matchedCount: matchedContactInfo.length, boardId })
 
   return { successful: true, matchedContactInfo }
 }
@@ -1077,18 +998,13 @@ async function createContact({ phoneNumber, newContactName, accessToken, authHea
 
   await trackAnalytics({ user, crm: 'Monday', event: 'contactCreated' });
 
-  const createdBoardName =
-    (user?.platformAdditionalInfo || user?.dataValues?.platformAdditionalInfo || {})?.boardName
-  const createdBoardLabel = boardDisplayLabel({ boardName: createdBoardName, boardId })
   return {
     contactInfo: {
       id: created.id,
       name: created.name,
-      // `type`/`contactType` carry the board name (self-labeled "Board: …") for display; `boardId`
-      // targets the board for logging, and the deep-link URL resolves the board via the
-      // {contactBoardId} setting.
-      type: createdBoardLabel,
-      contactType: createdBoardLabel,
+      // `type` feeds the RC entity contactType so logging/URLs target the right board.
+      type: String(boardId),
+      contactType: String(boardId),
       boardId
     },
     returnMessage: {
@@ -1124,12 +1040,10 @@ async function createCallLog({ contactInfo, callLog, note, aiNote, transcript, a
     authHeader?.replace('Bearer ', '') || accessToken || user?.accessToken
   // Log directly against the contact passed in — like ServiceTitan/ServiceNow — instead of
   // re-querying Monday for the board. create_update only needs the item id (contactInfo.id),
-  // so no board lookup ("search") is needed on the main path. The board id is only needed for
-  // an optional recording upload, which resolves it lazily below. In single-board mode we read
-  // the persisted board id off the user record (no API call) — `contactInfo.type` now carries
-  // the board NAME for display, so it can no longer double as the board id.
-  const persistedPai = user?.platformAdditionalInfo || user?.dataValues?.platformAdditionalInfo || {};
-  const boardId = String(contactInfo?.boardId || persistedPai.boardId || '') || null;
+  // so no board lookup ("search") is needed on the main path. The board id is carried on the
+  // contact (smuggled via `type`); it's only needed for an optional recording upload, which
+  // resolves it lazily below. This keeps logging working even if board discovery is slow/down.
+  const boardId = String(contactInfo?.boardId || contactInfo?.type || '') || null;
   // Fall back to a generated subject when no custom subject is supplied — matches every
   // other connector (clio/insightly/netsuite) and avoids the blank "Subject:" line.
   const defaultSubject = `${callLog.direction} Call ${callLog.direction === 'Outbound' ? 'to' : 'from'} ${contactInfo?.name || 'contact'}`
@@ -1436,24 +1350,6 @@ async function updateCallLog({ existingCallLog, recordingLink, recordingDownload
   }
 
   const body = lines.join("<br>").replace(/^(<br>)+|(<br>)+$/g, '');
-
-  // ---- Recording Upload (recording-sync) ----
-  // RingCentral recordings are usually NOT ready when the call is first logged, so
-  // createCallLog's upload is skipped and the recording only arrives here, on the later
-  // recording-sync, as `recordingDownloadLink`. Upload it now so the MP3 lands in the board's
-  // Files column. Dedupe against the case where the recording WAS ready at create: if the
-  // existing log body already has a Recording section (`parsed.recording`), createCallLog
-  // already handled the file — skip to avoid a duplicate upload.
-  if (recordingDownloadLink && !parsed.recording && itemId && (user.userSettings?.addCallLogRecording?.value ?? true)) {
-    try {
-      const uploadBoardId = await resolveBoardId({ accessToken: resolvedAccessToken, user })
-      const fileName = `Call-${Date.now()}.mp3`
-      const s3Url = await downloadAudioFile(recordingDownloadLink, process.env.S3_BUCKET, fileName)
-      await uploadToMonday({ s3Url, accessToken: resolvedAccessToken, itemId, fileName, boardId: uploadBoardId })
-    } catch (e: any) {
-      console.warn('[Monday][updateCallLog] recording upload failed:', e.message)
-    }
-  }
 
   // 2. Edit the existing update if we could read it.
   if (canEditExisting) {
@@ -2104,7 +2000,6 @@ exports.getAuthType = getAuthType;
 exports.getOauthInfo = getOauthInfo;
 exports.getOverridingOAuthOption = getOverridingOAuthOption;
 exports.getUserInfo = getUserInfo;
-exports.postSaveUserInfo = postSaveUserInfo;
 exports.unAuthorize = unAuthorize;
 exports.findContact = findContact;
 exports.findContactWithName = findContactWithName;

--- a/src/connectors/monday/index.ts
+++ b/src/connectors/monday/index.ts
@@ -554,10 +554,13 @@ async function getUserInfo({ authHeader, hostname, query }) {
     // Discover the connector's single board once, at connect time, and store it so the
     // rest of the system reuses it without re-discovering.
     let boardId = null;
+    let boardName = null;
     try {
       const boards = await getCrmBoards({ accessToken, userId: null, operation: 'getUserInfo' });
-      boardId = pickDefaultBoard(boards)?.id || null;
-      console.log('[Monday][getUserInfo] selected board', { boardId, discoveredBoardCount: boards.length });
+      const defaultBoard = pickDefaultBoard(boards);
+      boardId = defaultBoard?.id || null;
+      boardName = defaultBoard?.name || null;
+      console.log('[Monday][getUserInfo] selected board', { boardId, boardName, discoveredBoardCount: boards.length });
     } catch (e) {
       console.warn('[Monday][getUserInfo] board discovery failed (will retry lazily):', e.message);
     }
@@ -571,7 +574,7 @@ async function getUserInfo({ authHeader, hostname, query }) {
         email: userData.email,
         overridingApiKey: accessToken,
         ...(cleanHostname ? { overridingHostname: cleanHostname } : {}),
-        platformAdditionalInfo: { ...(boardId ? { boardId } : {}) }
+        platformAdditionalInfo: { ...(boardId ? { boardId, boardName } : {}) }
       },
       returnMessage: { messageType: 'success', message: 'Successfully connected to Monday.', ttl: 3000 }
     };
@@ -583,6 +586,33 @@ async function getUserInfo({ authHeader, hostname, query }) {
       returnMessage: { messageType: 'error', message: 'Monday authentication failed.', ttl: 3000 }
     };
   }
+}
+
+// Runs right after the user record is saved during OAuth connect (before the extension
+// fetches user settings). Seed the contactBoardId setting here — the framework hardcodes
+// `userSettings: {}` on create, so this is the earliest point we can populate it. Seeding at
+// connect (rather than lazily in findContact/getBoardId) ensures the {contactBoardId} URL
+// token resolves on the very first call-pop without the user opening Settings to enter it.
+async function postSaveUserInfo({ userInfo, oauthApp }) {
+  try {
+    // saveUserInfo returns only { id, name } — NOT the Sequelize instance — so re-fetch the
+    // persisted user to read platformAdditionalInfo.boardId (stored by getUserInfo at connect)
+    // and write userSettings.contactBoardId before the extension loads settings.
+    const userId = userInfo?.id;
+    if (userId) {
+      const user = await UserModel.findByPk(userId);
+      const pai = user?.platformAdditionalInfo || user?.dataValues?.platformAdditionalInfo || {};
+      if (user && pai.boardId) {
+        await seedContactBoardIdSetting(user, String(pai.boardId));
+        console.log('[Monday][postSaveUserInfo] seeded contactBoardId at connect', { userId, boardId: pai.boardId });
+      } else {
+        console.warn('[Monday][postSaveUserInfo] no boardId on user record; contactBoardId not seeded', { userId, hasUser: !!user });
+      }
+    }
+  } catch (e: any) {
+    console.warn('[Monday][postSaveUserInfo] failed to seed contactBoardId:', e.message);
+  }
+  return userInfo;
 }
 
 async function unAuthorize({ user }) {
@@ -661,9 +691,43 @@ function getUserId(user) {
 // The connector uses a single board for everything. It is discovered once (the default
 // board with a Phone column), stored on the user record's platformAdditionalInfo, and
 // reused everywhere — no per-contact board lookup.
+// Self-labeling display value for a matched/created contact's `type`/`contactType`. Renders
+// as e.g. "Board: Sales Leads" so the board name is distinguishable from the numeric Monday
+// item (pulse) id shown alongside it. Falls back to the board id when the name is unknown
+// (e.g. users connected before boardName was persisted). Used only for display — the deep-link
+// URL resolves the board via the {contactBoardId} setting and logging reads the persisted id.
+function boardDisplayLabel({ boardName, boardId }: { boardName?: any, boardId?: any }) {
+  const val = boardName || (boardId != null ? String(boardId) : '');
+  return val ? `Board: ${val}` : '';
+}
+
+// Auto-populate the per-user `contactBoardId` setting so the {contactBoardId} URL token
+// (contactPageUrl/logPageUrl/callPopUrl) resolves without the admin entering it manually.
+// The token reads from `userSettings.contactBoardId.value`. Written only when it differs, to
+// avoid redundant DB writes. This also backfills users whose board was persisted before the
+// feature existed.
+async function seedContactBoardIdSetting(user: any, boardId: string) {
+  if (!boardId || typeof user?.update !== 'function') return;
+  const current = user.userSettings || user.dataValues?.userSettings || {};
+  if (String(current?.contactBoardId?.value ?? '') === String(boardId)) return;
+  try {
+    const nextSettings = { ...current, contactBoardId: { value: String(boardId) } };
+    await user.update({ userSettings: nextSettings });
+    if (typeof user.changed === 'function') {
+      user.changed('userSettings', true);
+      if (typeof user.save === 'function') await user.save();
+    }
+    console.log('[Monday][board] seeded contactBoardId setting', { boardId });
+  } catch (e: any) {
+    console.warn('[Monday][board] failed to seed contactBoardId setting:', e.message);
+  }
+}
+
 async function getBoardId({ user, accessToken, operation = 'getBoardId' }) {
   const pai = user?.platformAdditionalInfo || user?.dataValues?.platformAdditionalInfo || {};
   if (pai.boardId) {
+    // Backfill the contactBoardId setting for users whose board was persisted earlier.
+    await seedContactBoardIdSetting(user, String(pai.boardId));
     return String(pai.boardId);
   }
   // Not stored yet — discover the default board and persist it on the user record.
@@ -673,7 +737,7 @@ async function getBoardId({ user, accessToken, operation = 'getBoardId' }) {
   console.log('[Monday][board] discovered board', { boardId, boardName: board?.name, discoveredBoardCount: boards.length });
   if (boardId && typeof user?.update === 'function') {
     try {
-      const nextPai = { ...pai, boardId };
+      const nextPai = { ...pai, boardId, boardName: board?.name || pai.boardName };
       await user.update({ platformAdditionalInfo: nextPai });
       // JSON columns don't always auto-flag as changed; force a save to be safe.
       if (typeof user.changed === 'function') {
@@ -684,6 +748,8 @@ async function getBoardId({ user, accessToken, operation = 'getBoardId' }) {
     } catch (e) {
       console.warn('[Monday][board] failed to persist boardId on user record:', e.message);
     }
+    // Seed the contactBoardId setting so the {contactBoardId} URL token resolves.
+    await seedContactBoardIdSetting(user, String(boardId));
   }
   return boardId;
 }
@@ -814,38 +880,48 @@ async function findContact({ phoneNumber, accessToken, authHeader, user, isExten
   }
 
   const resolvedAccessToken = authHeader?.replace('Bearer ', '') || accessToken || user?.accessToken
-  // Contacts can live on ANY board, so search every accessible CRM board (each active board
-  // with a Phone column), not just the single default board. Each match is tagged with the id
-  // of the board it was found on, so `type`/`contactType` (the {contactType} URL variable)
-  // points the "open contact" / "view call log" links at that contact's actual board.
-  let boards = []
+
+  // ── SINGLE-BOARD MODE ─────────────────────────────────────────────────────────────────
+  // Multi-board search is disabled for now. Contacts are matched against the connector's
+  // single default board. `boardId` is kept for logging; `type`/`contactType` now carry the
+  // board NAME (shown in the contact list) since the deep-link URL uses the {contactBoardId}
+  // setting token, not {contactType}. We also seed that setting from the resolved board.
+  //
+  // --- multi-board search (commented out; restore to search every board) ---
+  // let boards = []
+  // try { boards = await getCrmBoards({ accessToken: resolvedAccessToken, userId: getUserId(user) }) }
+  // catch (e) { return { successful: false, returnMessage: { messageType: 'warning', message: 'Monday is taking too long to respond. Please try again.', ttl: 3000 } } }
+  // const perBoardMatches = await Promise.all(boards.map(async board => { ... type: String(board.id) ... }))
+  // --------------------------------------------------------------------------
+  let board: any = null
   try {
-    boards = await getCrmBoards({ accessToken: resolvedAccessToken, userId: getUserId(user), operation: 'findContact' })
-  } catch (e) {
+    const boards = await getCrmBoards({ accessToken: resolvedAccessToken, userId: getUserId(user), operation: 'findContact' })
+    board = pickDefaultBoard(boards)
+  } catch (e: any) {
     // A board-discovery failure (e.g. a slow query hitting the request timeout) should not
     // surface as a hard error — tell the user to retry.
     console.warn('[Monday] findContact: board discovery failed', e.message)
     return { successful: false, returnMessage: { messageType: 'warning', message: 'Monday is taking too long to respond. Please try again.', ttl: 3000 } }
   }
-  if (!boards || boards.length === 0) {
+  if (!board) {
     return { successful: false, returnMessage: { messageType: 'error', message: 'No Monday board with a Phone column was found. Add a Phone column to your board and try again.', ttl: 3000 } }
   }
+  // Auto-populate the contactBoardId setting so the {contactBoardId} URL token resolves.
+  await seedContactBoardIdSetting(user, String(board.id))
 
+  const boardName = board.name || String(board.id)
   const phone = normalizePhone(phoneNumber)
-  const matchedContactInfo = []
+  const matchedContactInfo: any[] = []
 
   if (phone) {
-    // Search each board's Phone column in parallel, tagging every match with its board id.
-    const perBoardMatches = await Promise.all(boards.map(async board => {
-      const phoneColumnId = board.phoneColumnId || await getPhoneColumnId({ accessToken: resolvedAccessToken, boardId: board.id, operation: 'findContact' })
-      if (!phoneColumnId) return []
-      const items = await searchBoardByPhone({ accessToken: resolvedAccessToken, boardId: board.id, phoneColumnId, phone, operation: 'findContact' })
-      // The extension reads `type` off the contact to build the RC entity's contactType
-      // (contacts/match.js), which feeds the {contactType} URL variable. Set both names to be safe.
-      return items.map(item => ({ id: item.id, name: item.name, phone, type: String(board.id), contactType: String(board.id), boardId: board.id }))
-    }))
-    for (const boardMatches of perBoardMatches) {
-      matchedContactInfo.push(...boardMatches)
+    const phoneColumnId = board.phoneColumnId || await getPhoneColumnId({ accessToken: resolvedAccessToken, boardId: board.id })
+    if (phoneColumnId) {
+      const items = await searchBoardByPhone({ accessToken: resolvedAccessToken, boardId: board.id, phoneColumnId, phone })
+      const boardLabel = boardDisplayLabel({ boardName, boardId: board.id })
+      for (const item of items) {
+        // Display the board name (self-labeled "Board: …") in the contact list; keep boardId for logging.
+        matchedContactInfo.push({ id: item.id, name: item.name, phone, type: boardLabel, contactType: boardLabel, boardId: board.id, boardName })
+      }
     }
 
     if (matchedContactInfo.length === 0 && user?.rcAccountId) {
@@ -929,8 +1005,11 @@ async function findContactWithName({ name, accessToken, authHeader, user }) {
   }
 
   // `type` feeds the RC entity contactType (contacts/match.js) → {contactType} URL var.
-  const matchedContactInfo = items.map(item => ({ id: item.id, name: item.name, type: String(boardId), contactType: String(boardId), boardId }))
-  apiLog.logSuccess('Monday', 'findContactWithName', { name: term, matchedCount: matchedContactInfo.length, boardId })
+  // Match findContact's display: board name (self-labeled), not the raw boardId.
+  const wnPai = user?.platformAdditionalInfo || user?.dataValues?.platformAdditionalInfo || {}
+  const wnBoardLabel = boardDisplayLabel({ boardName: wnPai.boardName, boardId })
+  const matchedContactInfo = items.map(item => ({ id: item.id, name: item.name, type: wnBoardLabel, contactType: wnBoardLabel, boardId, boardName: wnPai.boardName }))
+  console.log('[Monday] findContactWithName', { term, matches: matchedContactInfo.length })
 
   return { successful: true, matchedContactInfo }
 }
@@ -1011,13 +1090,18 @@ async function createContact({ phoneNumber, newContactName, accessToken, authHea
 
   await trackAnalytics({ user, crm: 'Monday', event: 'contactCreated' });
 
+  const createdBoardName =
+    (user?.platformAdditionalInfo || user?.dataValues?.platformAdditionalInfo || {})?.boardName
+  const createdBoardLabel = boardDisplayLabel({ boardName: createdBoardName, boardId })
   return {
     contactInfo: {
       id: created.id,
       name: created.name,
-      // `type` feeds the RC entity contactType so logging/URLs target the right board.
-      type: String(boardId),
-      contactType: String(boardId),
+      // `type`/`contactType` carry the board name (self-labeled "Board: …") for display; `boardId`
+      // targets the board for logging, and the deep-link URL resolves the board via the
+      // {contactBoardId} setting.
+      type: createdBoardLabel,
+      contactType: createdBoardLabel,
       boardId
     },
     returnMessage: {
@@ -1053,10 +1137,12 @@ async function createCallLog({ contactInfo, callLog, note, aiNote, transcript, a
     authHeader?.replace('Bearer ', '') || accessToken || user?.accessToken
   // Log directly against the contact passed in — like ServiceTitan/ServiceNow — instead of
   // re-querying Monday for the board. create_update only needs the item id (contactInfo.id),
-  // so no board lookup ("search") is needed on the main path. The board id is carried on the
-  // contact (smuggled via `type`); it's only needed for an optional recording upload, which
-  // resolves it lazily below. This keeps logging working even if board discovery is slow/down.
-  const boardId = String(contactInfo?.boardId || contactInfo?.type || '') || null;
+  // so no board lookup ("search") is needed on the main path. The board id is only needed for
+  // an optional recording upload, which resolves it lazily below. In single-board mode we read
+  // the persisted board id off the user record (no API call) — `contactInfo.type` now carries
+  // the board NAME for display, so it can no longer double as the board id.
+  const persistedPai = user?.platformAdditionalInfo || user?.dataValues?.platformAdditionalInfo || {};
+  const boardId = String(contactInfo?.boardId || persistedPai.boardId || '') || null;
   // Fall back to a generated subject when no custom subject is supplied — matches every
   // other connector (clio/insightly/netsuite) and avoids the blank "Subject:" line.
   const defaultSubject = `${callLog.direction} Call ${callLog.direction === 'Outbound' ? 'to' : 'from'} ${contactInfo?.name || 'contact'}`
@@ -1363,6 +1449,24 @@ async function updateCallLog({ existingCallLog, recordingLink, recordingDownload
   }
 
   const body = lines.join("<br>").replace(/^(<br>)+|(<br>)+$/g, '');
+
+  // ---- Recording Upload (recording-sync) ----
+  // RingCentral recordings are usually NOT ready when the call is first logged, so
+  // createCallLog's upload is skipped and the recording only arrives here, on the later
+  // recording-sync, as `recordingDownloadLink`. Upload it now so the MP3 lands in the board's
+  // Files column. Dedupe against the case where the recording WAS ready at create: if the
+  // existing log body already has a Recording section (`parsed.recording`), createCallLog
+  // already handled the file — skip to avoid a duplicate upload.
+  if (recordingDownloadLink && !parsed.recording && itemId && (user.userSettings?.addCallLogRecording?.value ?? true)) {
+    try {
+      const uploadBoardId = await resolveBoardId({ accessToken: resolvedAccessToken, user })
+      const fileName = `Call-${Date.now()}.mp3`
+      const s3Url = await downloadAudioFile(recordingDownloadLink, process.env.S3_BUCKET, fileName)
+      await uploadToMonday({ s3Url, accessToken: resolvedAccessToken, itemId, fileName, boardId: uploadBoardId })
+    } catch (e: any) {
+      console.warn('[Monday][updateCallLog] recording upload failed:', e.message)
+    }
+  }
 
   // 2. Edit the existing update if we could read it.
   if (canEditExisting) {
@@ -2013,6 +2117,7 @@ exports.getAuthType = getAuthType;
 exports.getOauthInfo = getOauthInfo;
 exports.getOverridingOAuthOption = getOverridingOAuthOption;
 exports.getUserInfo = getUserInfo;
+exports.postSaveUserInfo = postSaveUserInfo;
 exports.unAuthorize = unAuthorize;
 exports.findContact = findContact;
 exports.findContactWithName = findContactWithName;

--- a/src/connectors/monday/manifest.json
+++ b/src/connectors/monday/manifest.json
@@ -34,9 +34,9 @@
       "customState": "",
       "scope": "",
       "canOpenLogPage": true,
-      "contactPageUrl": "https://{hostname}/boards/{contactType}/pulses/{contactId}",
-      "logPageUrl": "https://{hostname}/boards/{contactType}/pulses/{contactId}",
-      "callPopUrl": "https://{hostname}/boards/{contactType}/pulses/{contactId}",
+      "contactPageUrl": "https://{hostname}/boards/{contactBoardId}/pulses/{contactId}",
+      "logPageUrl": "https://{hostname}/boards/{contactBoardId}/pulses/{contactId}",
+      "callPopUrl": "https://{hostname}/boards/{contactBoardId}/pulses/{contactId}",
       "embeddedOnCrmPage": {
         "welcomePage": {
           "docLink": "https://ringcentral.github.io/rc-unified-crm-extension/",
@@ -44,6 +44,18 @@
         }
       },
       "settings": [
+        {
+          "id": "mondayOptions",
+          "type": "section",
+          "name": "Monday options",
+          "items": [
+            {
+              "id": "contactBoardId",
+              "type": "inputField",
+              "name": "Contact board ID"
+            }
+          ]
+        },
         {
           "id": "mondayLogging",
           "type": "section",

--- a/src/connectors/servicenow/index.ts
+++ b/src/connectors/servicenow/index.ts
@@ -46,6 +46,39 @@ function normalizeHostname(raw) {
   return host.toLowerCase();
 }
 
+// Resolve the companies row for a connection. ServiceNow uses admin-managed OAuth:
+// clientId/clientSecret/authorizationUri/accessTokenUri/hostname all live in the
+// accountData table keyed by rcAccountId (managed-oauth-account), so rcAccountId is
+// the authoritative tenant key. The hostname reaching us is the managed-OAuth one and
+// may not match what the companies row was provisioned with — so lookups are tiered:
+//   1. rcAccountId + hostname — disambiguates accounts with one row per instance
+//   2. rcAccountId only       — rows without a hostname (admin-managed provisioning)
+//   3. hostname only          — LEGACY rows that predate rcAccountId (prevents lockout)
+async function findCompany({ rcAccountId, hostname }) {
+    if (!models?.companies) return null;
+    const cleanHostname = normalizeHostname(hostname);
+    let company = null;
+    if (rcAccountId && cleanHostname) {
+        company = await models.companies.findOne({
+            where: { rcAccountId: String(rcAccountId), hostname: cleanHostname, status: true },
+            raw: true
+        });
+    }
+    if (!company && rcAccountId) {
+        company = await models.companies.findOne({
+            where: { rcAccountId: String(rcAccountId), status: true },
+            raw: true
+        });
+    }
+    if (!company && cleanHostname) {
+        company = await models.companies.findOne({
+            where: { hostname: cleanHostname, status: true },
+            raw: true
+        });
+    }
+    return company;
+}
+
 async function getLicenseStatus({ userId }) {
     return licenseHelper.getLicenseStatus({ models, userId });
 }
@@ -53,18 +86,6 @@ async function getLicenseStatus({ userId }) {
 async function validateLicenseOrFail(user) {
     return licenseHelper.validateLicenseOrFail({ models, user });
 }
-
-//function to generate aplhanumeric string for admin login sysid
-function generateAlphanumericString(length) {
-    const chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
-    let result = '';
-    for (let i = 0; i < length; i++) {
-        const randomIndex = Math.floor(Math.random() * chars.length);
-        result += chars[randomIndex];
-    }
-    return result.toLowerCase();
-}
-
 
 function getAuthType() {
     return 'oauth'; // Return either 'oauth' OR 'apiKey'
@@ -128,9 +149,30 @@ async function getUserInfo({ authHeader, hostname, query }) {
         const timezoneName = result.time_zone ?? '';
         const timezoneOffset = result.time_zone_offset ?? null;
 
-        // Admin sys_id — generate a unique id so admin can also connect
+        const rcUserEmail = query?.rcUserEmail;
+        const rcUserName = query?.rcUserName;
+
+        // Admin sys_id is identical across ALL ServiceNow instances (out-of-box record),
+        // so it can't be used as-is. It must map to a STABLE id — a random one would mint
+        // a new user (and seat) on every login. Same approach as ServiceTitan: key on the
+        // RC identity — rcExtensionId when genuinely distinct from rcAccountId, else the
+        // normalized email — falling back to a per-instance hash (deterministic, never random).
         if (id === '6816f79cc0a8016401c5a33be04be441') {
-            id = generateAlphanumericString(id.length);
+            const rcExtensionId = query?.rcExtensionId;
+            const emailKey = rcUserEmail ? String(rcUserEmail).trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') : '';
+            const perUserKey =
+                (rcExtensionId && String(rcExtensionId) !== String(rcAccountId)) ? String(rcExtensionId)
+                    : (emailKey || (rcExtensionId ? String(rcExtensionId) : ''));
+            id = perUserKey
+                ? `admin-${perUserKey}`
+                : crypto.createHash('sha256').update(`snow-admin:${normalizeHostname(hostname)}`).digest('hex').slice(0, 32);
+            console.log('[ServiceNow][getUserInfo] admin sys_id remapped to stable id', {
+                hasRcExtensionId: !!rcExtensionId,
+                extIdSameAsAccount: !!(rcExtensionId && String(rcExtensionId) === String(rcAccountId)),
+                hasRcUserEmail: !!rcUserEmail,
+                usedFallbackHash: !perUserKey,
+                id
+            });
         }
 
         // Tenant-scope the id so the same ServiceNow user under different RC accounts
@@ -142,29 +184,12 @@ async function getUserInfo({ authHeader, hostname, query }) {
             id = `snow-${rcAccountId}-${id}`;
         }
 
-        const rcUserEmail = query?.rcUserEmail;
-        const rcUserName = query?.rcUserName;
-
         if (models && models.companies && models.customer && rcAccountId) {
             try {
-                const cleanHostname = normalizeHostname(hostname);
-                let company = null;
-                if (rcAccountId && cleanHostname) {
-                    company = await models.companies.findOne({
-                        where: { rcAccountId: String(rcAccountId), hostname: cleanHostname, status: true },
-                        raw: true
-                    });
-                }
-                if (!company && rcAccountId) { // fixed-hostname / rows without a hostname
-                    company = await models.companies.findOne({
-                        where: { rcAccountId: String(rcAccountId), status: true }, raw: true
-                    });
-                }
-                if (!company && cleanHostname) { // LEGACY rows that predate rcAccountId ← prevents the lockout
-                    company = await models.companies.findOne({
-                        where: { hostname: cleanHostname, status: true }, raw: true
-                    });
-                }
+                // Reaching this point means the core already resolved the managed-OAuth
+                // config from accountData for this rcAccountId (our getOauthInfo only
+                // returns a failMessage), so rcAccountId is the reliable tenant key here.
+                const company = await findCompany({ rcAccountId, hostname });
                 if (!company) {
                     return {
                         successful: false,
@@ -350,11 +375,7 @@ async function findContact({ user, authHeader, phoneNumber, overridingFormat, is
     const hostname = userInfo.hostname;
     console.log("hostname", hostname)
 
-    const companyData = await models.companies.findOne({
-        where: {
-            hostname: normalizeHostname(hostname)
-        }
-    });
+    const companyData = await findCompany({ rcAccountId: user.rcAccountId, hostname });
 
     let states = [];
     let interactionType = [];
@@ -534,12 +555,8 @@ async function createCallLog({ user, contactInfo, authHeader, callLog, note, add
 
     const userInfo = await getHostname(user.dataValues.hostname);
 
-    const { userDetailsPath } = await models.companies.findOne({
-        where: {
-            hostname: normalizeHostname(userInfo.hostname)
-        },
-        raw: true
-    })
+    const companyData = await findCompany({ rcAccountId: user.rcAccountId, hostname: userInfo.hostname });
+    const userDetailsPath = companyData?.userDetailsPath;
 
     if (!userDetailsPath) {
         return {
@@ -561,11 +578,6 @@ async function createCallLog({ user, contactInfo, authHeader, callLog, note, add
 
     const instanceId = userInfo.instanceId;
     const hostname = userInfo.hostname;
-    const companyData = await models.companies.findOne({
-        where: {
-            hostname: normalizeHostname(hostname)
-        }
-    });
 
     const contactTable = (companyData?.contactTable == 'user') ? 'table/sys_user' : 'contact';
 
@@ -982,12 +994,8 @@ async function createMessageLog({ user, contactInfo, authHeader, message, additi
     const instanceId = userInfo.instanceId;
     const hostname = userInfo.hostname;
 
-    const { userDetailsPath } = await models.companies.findOne({
-        where: {
-            hostname: normalizeHostname(hostname)
-        },
-        raw: true
-    })
+    const messageLogCompany = await findCompany({ rcAccountId: user.rcAccountId, hostname });
+    const userDetailsPath = messageLogCompany?.userDetailsPath;
 
     if (!userDetailsPath) {
         return {
@@ -1218,11 +1226,7 @@ async function createContact({ user, authHeader, phoneNumber, newContactName, ne
     const instanceId = userInfo.instanceId;
     const hostname = userInfo.hostname;
 
-    const companyData = await models.companies.findOne({
-        where: {
-            hostname: normalizeHostname(hostname)
-        }
-    });
+    const companyData = await findCompany({ rcAccountId: user.rcAccountId, hostname });
 
     const postBody = {
         phone: phoneNumber,

--- a/src/connectors/servicetitan/index.ts
+++ b/src/connectors/servicetitan/index.ts
@@ -21,9 +21,8 @@ const serviceTitanApiClient = axios.create();
 
 // Env-driven so the same connector works in integration and production (the token URL is
 // already env-driven via SERVICETITAN_ACCESS_TOKEN_URI). Defaults to the integration/sandbox
-// host so existing behaviour is unchanged. For production set SERVICETITAN_CRM_URL /
-// SERVICETITAN_JPM_URL to the api.servicetitan.io equivalents (and matching prod creds).
-const SERVICE_TITAN_JPM_URL = process.env.SERVICETITAN_JPM_URL || "https://api-integration.servicetitan.io/jpm/v2/tenant"
+// host so existing behaviour is unchanged. For production set SERVICETITAN_CRM_URL to the
+// api.servicetitan.io equivalent (and matching prod creds).
 const SERVICE_TITAN_CRM_URL = process.env.SERVICETITAN_CRM_URL || "https://api-integration.servicetitan.io/crm/v2/tenant"
 
 
@@ -45,7 +44,8 @@ function getBasicAuth({ apiKey }) {
     return Buffer.from(`${apiKey}`).toString('base64');
 }
 
-async function getUserInfo({ hostname, additionalInfo }) {
+async function getUserInfo({ hostname, additionalInfo, authHeader }) {
+    console.log("Authheader: ", authHeader)
     // RC identity arrives via the manifest's rcAdditionalSubmission (auto-pulled from RC
     // cached data — no user prompt, no framework change). ServiceTitan API auth is
     // app-level (client_credentials); the email field has been removed.
@@ -150,7 +150,7 @@ async function getUserInfo({ hostname, additionalInfo }) {
     try {
         const accessToken = await generateServiceTitanToken(clientId, clientSecret);
 
-        apiLog.logSuccess('ServiceTitan', 'getUserInfo', { userId, tenantId, apiEndpoint: process.env.SERVICETITAN_ACCESS_TOKEN_URI });
+        apiLog.logSuccess('ServiceTitan', 'getUserInfo', { userId, tenantId, apiEndpoint: process.env.SERVICE_TITAN_ACCESS_TOKEN_URI });
 
         return {
             successful: true,
@@ -251,26 +251,6 @@ async function findContact({ user, phoneNumber, isExtension }) {
 
             rawPersonInfo['phoneNumber'] = phoneNumber;
             const contact = formatContact(rawPersonInfo);
-
-            // Fetch active/scheduled jobs for this customer and attach them as dropdown
-            // options — the RC extension reads additionalInfo to populate contactDependent
-            // selection fields (same pattern as ServiceNow's state/type/account fields).
-            let jobOptions = [{ const: 'none', title: 'None' }];
-            try {
-                const jobs = await fetchJobs({ user, params: { customerId: contact.id } });
-                const activeJobs = jobs.map(job => ({
-                    const: String(job.id),
-                    title: `[#${job.jobNumber || job.id}] ${job.type?.name || job.jobTypeName || 'Job'}${job.status ? ' \u2013 ' + job.status : ''}`
-                }));
-                jobOptions.push(...activeJobs);
-            } catch (err) {
-                console.warn('[ServiceTitan] findContact: failed to fetch jobs for customer', contact.id, err.message);
-            }
-
-            contact.additionalInfo = {
-                associatedJobs: jobOptions
-            };
-
             matchedContactInfo.push(contact);
         }
     }
@@ -344,24 +324,6 @@ async function findContactWithName({ user, name }) {
                 const phone = rawPersonInfo.phones?.find(p => p.type === 'Primary')?.phone ?? '';
                 rawPersonInfo['phoneNumber'] = phone;
                 const contact = formatContact(rawPersonInfo);
-
-                // Fetch active/scheduled jobs for this customer
-                let jobOptions = [{ const: 'none', title: 'None (Log to Customer Note)' }];
-                try {
-                    const jobs = await fetchJobs({ user, params: { customerId: contact.id } });
-                    const activeJobs = jobs.map(job => ({
-                        const: String(job.id),
-                        title: `[#${job.jobNumber || job.id}] ${job.type?.name || job.jobTypeName || 'Job'}${job.status ? ' \u2013 ' + job.status : ''}`
-                    }));
-                    jobOptions.push(...activeJobs);
-                } catch (err) {
-                    console.warn('[ServiceTitan] findContactWithName: failed to fetch jobs for customer', contact.id, err.message);
-                }
-
-                contact.additionalInfo = {
-                    associatedJobs: jobOptions
-                };
-
                 matchedContactInfo.push(contact);
             }
         }
@@ -514,80 +476,6 @@ async function getUserList({ user, authHeader }) {
     }
 }
 
-async function fetchJobs({ user, params = {} }) {
-    try {
-        apiLog.logStart('ServiceTitan', 'fetchJobs', { customerId: params?.customerId });
-
-        const auth = await getRefreshedAuthToken(user);
-        const tenantId = user.dataValues.platformAdditionalInfo.tenant;
-        const stAppKey = user.dataValues.platformAdditionalInfo.st_app_key;
-
-        // ServiceTitan API does not support comma-separated jobStatus. 
-        // We must fetch each active status individually and merge them.
-        const activeStatuses = ['Scheduled', 'Dispatched', 'InProgress'];
-
-        const jobPromises = activeStatuses.map(status => {
-            const fetchJobsUrl = `${SERVICE_TITAN_JPM_URL}/${tenantId}/jobs?pageSize=10&jobStatus=${status}&customerId=${params?.customerId}&active=true`;
-            return serviceTitanApiClient.get(
-                fetchJobsUrl,
-                {
-                    headers: {
-                        'Authorization': `Bearer ${auth}`,
-                        'ST-App-Key': stAppKey
-                    },
-                    _operation: 'fetchJobs'
-                }
-            ).catch(err => {
-                console.warn(`Failed to fetch ${status} jobs:`, err.message);
-                return { data: { data: [] } }; // Fallback for failed status
-            });
-        });
-
-        const responses = await Promise.all(jobPromises);
-        let jobs = [];
-        responses.forEach(resp => {
-            if (resp.data && resp.data.data) {
-                jobs = jobs.concat(resp.data.data);
-            }
-        });
-
-        // Fetch the human-readable job type names for the retrieved jobs
-        const jobTypeIds = [...new Set(jobs.filter(j => j.jobTypeId).map(j => j.jobTypeId))];
-        const jobTypePromises = jobTypeIds.map(typeId => {
-            const fetchJobTypeUrl = `${SERVICE_TITAN_JPM_URL}/${tenantId}/job-types/${typeId}`;
-            return serviceTitanApiClient.get(
-                fetchJobTypeUrl,
-                {
-                    headers: {
-                        'Authorization': `Bearer ${auth}`,
-                        'ST-App-Key': stAppKey
-                    },
-                    _operation: 'fetchJobs'
-                }
-            ).then(res => ({ id: typeId, name: res.data?.name || res.data?.data?.name }))
-                .catch(err => {
-                    console.warn(`Failed to fetch job type ${typeId}:`, err.message);
-                    return { id: typeId, name: 'Job' };
-                });
-        });
-
-        const jobTypes = await Promise.all(jobTypePromises);
-        const jobTypeMap = {};
-        jobTypes.forEach(jt => { jobTypeMap[jt.id] = jt.name; });
-
-        jobs.forEach(job => {
-            job.jobTypeName = jobTypeMap[job.jobTypeId] || 'Job';
-        });
-
-        apiLog.logSuccess('ServiceTitan', 'fetchJobs', { customerId: params?.customerId, count: jobs.length, apiEndpoint: `${SERVICE_TITAN_JPM_URL}/${tenantId}/jobs` });
-        return jobs;
-    } catch (err) {
-        console.error('fetchJobs error:', err?.response?.data, err?.response, err);
-        return [];
-    }
-}
-
-
 // ServiceTitan notes are PLAIN TEXT (no markdown/HTML rendering), so AI/RingSense content
 // arrives with literal "**...**" markers and uneven spacing. This tidies it for plain text:
 //  - a short, fully-bold line (a header like **Recap**) -> "Recap:" with a blank line BEFORE
@@ -697,81 +585,22 @@ async function createCallLog({ user, contactInfo, callLog, note, aiNote, transcr
     if (optionalSections) noteText += `\n\n${optionalSections}`;
     if (footerLines.length > 0) noteText += `\n\n${footerLines.join("\n")}`;
 
-    // Determine which job to attach the note to.
-    // Priority: 1) User's explicit dropdown selection (additionalSubmission)
-    //           2) User settings default (serviceTitanInboundCallJobId / serviceTitanOutboundCallJobId)
-    //           3) 'none' → customer-level note
-    let selectedJobId = additionalSubmission?.associatedJobs;
-
-    // If no job was selected (e.g. auto call logging with no cached selection),
-    // fall back to the user's configured default job ID from settings.
-    if (!selectedJobId || selectedJobId === 'none') {
-        const isInbound = callLog?.direction === 'Inbound';
-        const settingKey = isInbound ? 'serviceTitanInboundCallJobId' : 'serviceTitanOutboundCallJobId';
-        const defaultJobId = user.userSettings?.[settingKey]?.value;
-        if (defaultJobId && defaultJobId.trim() !== '') {
-            console.log(`[ServiceTitan][createCallLog] Using default job ID from settings (${settingKey}):`, defaultJobId);
-            selectedJobId = defaultJobId.trim();
-        } else {
-            selectedJobId = 'none';
+    // Always log to the customer-level note.
+    const createCallLogUrl = `${SERVICE_TITAN_CRM_URL}/${tenantId}/customers/${contactInfo.id}/notes`;
+    const addNoteRes = await serviceTitanApiClient.post(
+        createCallLogUrl,
+        { text: noteText },
+        {
+            headers: {
+                Authorization: `Bearer ${auth}`,
+                "ST-App-Key": stAppKey,
+                "Content-Type": "application/json"
+            },
+            _operation: 'createCallLog'
         }
-    }
-
-    // Validate the selected job against live data to prevent posting to a stale/invalid job.
-    if (selectedJobId && selectedJobId !== 'none') {
-        try {
-            const activeJobs = await fetchJobs({ user, params: { customerId: contactInfo.id } });
-            const jobStillActive = activeJobs.some(j => String(j.id) === String(selectedJobId));
-            if (!jobStillActive) {
-                console.log(`[ServiceTitan][createCallLog] Job ${selectedJobId} is not active for customer ${contactInfo.id} — falling back to customer note`);
-                selectedJobId = 'none';
-            }
-        } catch (err) {
-            console.warn('[ServiceTitan][createCallLog] Failed to validate job, falling back to customer note:', err.message);
-            selectedJobId = 'none';
-        }
-    }
-
-    let logId;
-
-    if (selectedJobId && selectedJobId !== 'none') {
-        // Post to job notes: POST /jpm/v2/tenant/{tenantId}/jobs/{jobId}/notes
-        const jobNoteUrl = `${SERVICE_TITAN_JPM_URL}/${tenantId}/jobs/${selectedJobId}/notes`;
-        const jobNoteRes = await serviceTitanApiClient.post(
-            jobNoteUrl,
-            { text: noteText },
-            {
-                headers: {
-                    Authorization: `Bearer ${auth}`,
-                    "ST-App-Key": stAppKey,
-                    "Content-Type": "application/json"
-                },
-                _operation: 'createCallLog'
-            }
-        );
-        // ServiceTitan job notes API does NOT return a note ID in the create response.
-        // Use the call session ID as a content-based identifier instead.
-        const csid = callLog.sessionId || callLog.telephonySessionId || `ts-${Date.now()}`;
-        logId = `csid-${csid}_${selectedJobId}_jobnote`;
-        apiLog.logSuccess('ServiceTitan', 'createCallLog', { logId, jobId: selectedJobId, apiEndpoint: jobNoteUrl });
-    } else {
-        // Default: customer-level note
-        const createCallLogUrl = `${SERVICE_TITAN_CRM_URL}/${tenantId}/customers/${contactInfo.id}/notes`;
-        const addNoteRes = await serviceTitanApiClient.post(
-            createCallLogUrl,
-            { text: noteText },
-            {
-                headers: {
-                    Authorization: `Bearer ${auth}`,
-                    "ST-App-Key": stAppKey,
-                    "Content-Type": "application/json"
-                },
-                _operation: 'createCallLog'
-            }
-        );
-        logId = `${addNoteRes.data.id}_note`;
-        apiLog.logSuccess('ServiceTitan', 'createCallLog', { logId, contactId: contactInfo.id, apiEndpoint: createCallLogUrl });
-    }
+    );
+    const logId = `${addNoteRes.data.id}_note`;
+    apiLog.logSuccess('ServiceTitan', 'createCallLog', { logId, contactId: contactInfo.id, apiEndpoint: createCallLogUrl });
 
     await trackAnalytics({ user, crm: 'ServiceTitan', event: 'callLogCreated', eventDate: callLog?.startTime });
 
@@ -799,18 +628,7 @@ async function updateCallLog({ user, existingCallLog, recordingLink, note, aiNot
 
     const contactId = existingCallLog.contactId;
 
-    let [noteId, jobId, logType] = existingCallLog.thirdPartyLogId.split("_");
-    // Legacy logIds were: {realId}_{note|job}  — 2 parts.
-    // New job-note logIds are: csid-{sessionId}_{jobId}_jobnote — 3 parts.
-    // Normalise: if only 2 parts, treat the second as logType and jobId is empty.
-    if (!logType) {
-        logType = jobId || 'note';
-        jobId = null;
-    }
-    const realId = noteId;
-    // Session-based IDs: job notes don't have native IDs from ServiceTitan API
-    const isSessionBased = realId.startsWith('csid-');
-    const sessionIdFromLog = isSessionBased ? realId.replace('csid-', '') : null;
+    const [realId] = existingCallLog.thirdPartyLogId.split("_");
 
     let direction = "";
     let startTime = "";
@@ -831,82 +649,21 @@ async function updateCallLog({ user, existingCallLog, recordingLink, note, aiNot
 
     // ---------------- FETCH OLD DATA ----------------
     let body = "";
-    if (logType === "jobnote") {
-        // Fetch the job note text — ServiceTitan job notes have no native IDs,
-        // so we match by Call Session ID embedded in the note text.
-        try {
-            const jobNoteListRes = await serviceTitanApiClient.get(
-                `${SERVICE_TITAN_JPM_URL}/${tenantId}/jobs/${jobId}/notes`,
-                {
-                    headers: {
-                        Authorization: `Bearer ${auth}`,
-                        "ST-App-Key": stAppKey
-                    },
-                    _operation: 'updateCallLog'
-                }
-            );
-            // ServiceTitan may return notes as { data: [...] } or { data: { data: [...] } }
-            const notes = Array.isArray(jobNoteListRes.data?.data)
-                ? jobNoteListRes.data.data
-                : Array.isArray(jobNoteListRes.data)
-                    ? jobNoteListRes.data
-                    : [];
-            console.log(`[ServiceTitan][updateCallLog] Fetched ${notes.length} job notes for job ${jobId}`);
-
-            if (isSessionBased && sessionIdFromLog) {
-                // Content-based matching: find note containing the Call Session ID
-                const targetNote = notes.find(n => {
-                    const text = n.text || n.note || '';
-                    return text.includes(`Call Session ID: ${sessionIdFromLog}`);
-                });
-                if (targetNote) {
-                    body = targetNote.text || targetNote.note || "";
-                    console.log(`[ServiceTitan][updateCallLog] Found job note by session ID ${sessionIdFromLog}, body length: ${body.length}`);
-                } else {
-                    console.warn(`[ServiceTitan][updateCallLog] No note found containing session ID ${sessionIdFromLog} in ${notes.length} notes`);
-                }
-            } else {
-                // Legacy ID-based matching fallback
-                const targetNote = notes.find(n => String(n.id) === String(realId));
-                if (targetNote) {
-                    body = targetNote.text || targetNote.note || "";
-                }
-            }
-        } catch (e) {
-            console.warn('[ServiceTitan][updateCallLog] could not fetch job notes', { realId, jobId, error: e?.message });
+    const getLogRes = await serviceTitanApiClient.get(
+        `${SERVICE_TITAN_CRM_URL}/${tenantId}/customers/${contactId}/notes`,
+        {
+            headers: {
+                Authorization: `Bearer ${auth}`,
+                "ST-App-Key": stAppKey
+            },
+            _operation: 'updateCallLog'
         }
-    } else if (logType === "note") {
+    );
 
-        const getLogRes = await serviceTitanApiClient.get(
-            `${SERVICE_TITAN_CRM_URL}/${tenantId}/customers/${contactId}/notes`,
-            {
-                headers: {
-                    Authorization: `Bearer ${auth}`,
-                    "ST-App-Key": stAppKey
-                },
-                _operation: 'updateCallLog'
-            }
-        );
+    const targetLog = getLogRes.data.data.find(log => log.id == realId);
 
-        const targetLog = getLogRes.data.data.find(log => log.id == realId);
-
-        if (targetLog) {
-            body = targetLog.text || "";
-        }
-    } else {
-        // Legacy job-summary logType ("job")
-        const jobRes = await serviceTitanApiClient.get(
-            `${SERVICE_TITAN_JPM_URL}/${tenantId}/jobs/${realId}`,
-            {
-                headers: {
-                    Authorization: `Bearer ${auth}`,
-                    "ST-App-Key": stAppKey
-                },
-                _operation: 'updateCallLog'
-            }
-        );
-
-        body = jobRes.data?.summary || "";
+    if (targetLog) {
+        body = targetLog.text || "";
     }
     let subjectToUse = "";
     if (body) {
@@ -1022,81 +779,37 @@ async function updateCallLog({ user, existingCallLog, recordingLink, note, aiNot
 
     // ---------------- UPDATE NOTE ----------------
 
-    if (logType === "jobnote") {
-        // Job note: create a new note on the job. ServiceTitan job notes have no native
-        // IDs, so we can't delete the old one by ID. We keep the session-based logId so
-        // subsequent updates can still find the latest note by session ID in the text.
-        await serviceTitanApiClient.post(
-            `${SERVICE_TITAN_JPM_URL}/${tenantId}/jobs/${jobId}/notes`,
-            { text: noteText },
-            {
-                headers: {
-                    Authorization: `Bearer ${auth}`,
-                    "ST-App-Key": stAppKey,
-                    "Content-Type": "application/json"
-                },
-                _operation: 'updateCallLog'
-            }
-        );
-        // Preserve the session-based logId so the next update can find the note by content
-        newLogId = isSessionBased
-            ? `csid-${sessionIdFromLog}_${jobId}_jobnote`
-            : `${realId}_${jobId}_jobnote`;
-        console.log(`[ServiceTitan][updateCallLog] Created updated job note, logId: ${newLogId}`);
-    } else if (logType === "note") {
-
-        // ServiceTitan customer notes have no in-place update endpoint, so an edit is a
-        // create-then-delete: post the replacement note, then delete the original so we don't
-        // leave a duplicate. Order matters — create first so a delete failure never loses the
-        // edited content (worst case is a leftover duplicate, not data loss).
-        const addNoteRes = await serviceTitanApiClient.post(
-            `${SERVICE_TITAN_CRM_URL}/${tenantId}/customers/${contactId}/notes`,
-            { text: noteText },
-            {
-                headers: {
-                    Authorization: `Bearer ${auth}`,
-                    "ST-App-Key": stAppKey,
-                    "Content-Type": "application/json"
-                },
-                _operation: 'updateCallLog'
-            }
-        );
-
-        newLogId = `${addNoteRes.data.id}_note`;
-
-        if (realId && String(addNoteRes.data.id) !== String(realId)) {
-            try {
-                await serviceTitanApiClient.delete(
-                    `${SERVICE_TITAN_CRM_URL}/${tenantId}/customers/${contactId}/notes/${realId}`,
-                    {
-                        headers: { Authorization: `Bearer ${auth}`, "ST-App-Key": stAppKey },
-                        _operation: 'updateCallLog'
-                    }
-                );
-            } catch (e) {
-                console.warn('[ServiceTitan][updateCallLog] could not delete the old note — a duplicate may remain', { oldNoteId: realId, status: e?.response?.status, message: e?.message });
-            }
+    // ServiceTitan customer notes have no in-place update endpoint, so an edit is a
+    // create-then-delete: post the replacement note, then delete the original so we don't
+    // leave a duplicate. Order matters — create first so a delete failure never loses the
+    // edited content (worst case is a leftover duplicate, not data loss).
+    const addNoteRes = await serviceTitanApiClient.post(
+        `${SERVICE_TITAN_CRM_URL}/${tenantId}/customers/${contactId}/notes`,
+        { text: noteText },
+        {
+            headers: {
+                Authorization: `Bearer ${auth}`,
+                "ST-App-Key": stAppKey,
+                "Content-Type": "application/json"
+            },
+            _operation: 'updateCallLog'
         }
-    }
+    );
 
-    // ---------------- UPDATE JOB ----------------
+    newLogId = `${addNoteRes.data.id}_note`;
 
-    else {
-
-        await serviceTitanApiClient.patch(
-            `${SERVICE_TITAN_JPM_URL}/${tenantId}/jobs/${realId}`,
-            { summary: noteText },
-            {
-                headers: {
-                    Authorization: `Bearer ${auth}`,
-                    "ST-App-Key": stAppKey,
-                    "Content-Type": "application/json"
-                },
-                _operation: 'updateCallLog'
-            }
-        );
-
-        newLogId = `${realId}_job`;
+    if (realId && String(addNoteRes.data.id) !== String(realId)) {
+        try {
+            await serviceTitanApiClient.delete(
+                `${SERVICE_TITAN_CRM_URL}/${tenantId}/customers/${contactId}/notes/${realId}`,
+                {
+                    headers: { Authorization: `Bearer ${auth}`, "ST-App-Key": stAppKey },
+                    _operation: 'updateCallLog'
+                }
+            );
+        } catch (e) {
+            console.warn('[ServiceTitan][updateCallLog] could not delete the old note — a duplicate may remain', { oldNoteId: realId, status: e?.response?.status, message: e?.message });
+        }
     }
 
     const logID_db = await CallLogModel.findOne({
@@ -1359,19 +1072,7 @@ async function getCallLog({ user, callLogId }) {
 
     apiLog.logStart('ServiceTitan', 'getCallLog', { logId: callLogId });
 
-    // Parse logId: supports both 2-part legacy ({id}_note or {id}_job)
-    // and 3-part job-note ({noteId}_{jobId}_jobnote).
-    const parts = callLogId.split("_");
-    let realId, jobId, logType;
-    if (parts.length >= 3) {
-        [realId, jobId, logType] = parts;
-    } else {
-        [realId, logType = "note"] = parts;
-        jobId = null;
-    }
-
-    const isSessionBased = realId.startsWith('csid-');
-    const sessionIdFromLog = isSessionBased ? realId.replace('csid-', '') : null;
+    const [realId] = callLogId.split("_");
 
     const auth = await getRefreshedAuthToken(user);
     const tenantId = user.dataValues.platformAdditionalInfo.tenant;
@@ -1383,77 +1084,39 @@ async function getCallLog({ user, callLogId }) {
 
     try {
 
-        // ---------------- JOB NOTE LOG (selected job from dropdown) ----------------
-        if (logType === "jobnote") {
+        const existingCallLogDetails = await CallLogModel.findOne({
+            where: { thirdPartyLogId: callLogId }
+        });
 
-            try {
-                const jobNoteListRes = await serviceTitanApiClient.get(
-                    `${SERVICE_TITAN_JPM_URL}/${tenantId}/jobs/${jobId}/notes`,
-                    {
-                        headers: {
-                            Authorization: `Bearer ${auth}`,
-                            "ST-App-Key": stAppKey
-                        },
-                        _operation: 'getCallLog'
-                    }
-                );
-
-                const notes = Array.isArray(jobNoteListRes.data?.data)
-                    ? jobNoteListRes.data.data
-                    : Array.isArray(jobNoteListRes.data)
-                        ? jobNoteListRes.data
-                        : [];
-
-                let targetNote;
-                if (isSessionBased && sessionIdFromLog) {
-                    // Content-based matching by Call Session ID
-                    targetNote = notes.find(n => {
-                        const text = n.text || n.note || '';
-                        return text.includes(`Call Session ID: ${sessionIdFromLog}`);
-                    });
-                } else {
-                    targetNote = notes.find(n => n.id == realId);
+        if (!existingCallLogDetails) {
+            return {
+                callLogInfo: {
+                    subject: "",
+                    note: "",
+                    fullLogResponse: {}
                 }
-
-                if (targetNote) {
-                    const body = targetNote.text || targetNote.note || "";
-                    const normalized = body.replace(/\r\n/g, '\n');
-
-                    const subjectMatch = normalized.match(/Subject:\s*(.*?)(?:\n|$)/);
-                    subject = subjectMatch ? subjectMatch[1].trim() : '';
-
-                    if (!subject || subject.toLowerCase().startsWith('direction:')) {
-                        subject = '';
-                    }
-
-                    const agentMatch = normalized.match(/Agent Notes:\s*([\s\S]*?)(?:\n[A-Za-z][^\n]*:|$)/);
-                    if (agentMatch) {
-                        note = agentMatch[1].trim();
-                    }
-
-                    full_data = body;
-                }
-            } catch (e) {
-                console.warn('[ServiceTitan][getCallLog] could not fetch job note', { realId, jobId, error: e?.message });
-            }
+            };
         }
 
-        // ---------------- LEGACY JOB SUMMARY LOG ----------------
-        else if (logType === "job") {
+        const contactId = existingCallLogDetails.contactId;
 
-            const jobRes = await serviceTitanApiClient.get(
-                `${SERVICE_TITAN_JPM_URL}/${tenantId}/jobs/${realId}`,
-                {
-                    headers: {
-                        Authorization: `Bearer ${auth}`,
-                        "ST-App-Key": stAppKey
-                    },
-                    _operation: 'getCallLog'
-                }
-            );
+        const getLogRes = await serviceTitanApiClient.get(
+            `${SERVICE_TITAN_CRM_URL}/${tenantId}/customers/${contactId}/notes`,
+            {
+                headers: {
+                    Authorization: `Bearer ${auth}`,
+                    "ST-App-Key": stAppKey
+                },
+                _operation: 'getCallLog'
+            }
+        );
 
-            const summary = jobRes.data?.summary || "";
-            const normalized = summary.replace(/\r\n/g, '\n');
+        const targetLog = getLogRes.data.data.find(log => log.id == realId);
+
+        if (targetLog) {
+
+            const body = targetLog.text || "";
+            const normalized = body.replace(/\r\n/g, '\n');
 
             const subjectMatch = normalized.match(/Subject:\s*(.*?)(?:\n|$)/);
             subject = subjectMatch ? subjectMatch[1].trim() : '';
@@ -1468,64 +1131,7 @@ async function getCallLog({ user, callLogId }) {
                 note = agentMatch[1].trim();
             }
 
-            full_data = {
-                subject,
-                description: summary
-            };
-        }
-
-        // ---------------- NOTE LOG ----------------
-        else {
-
-            const existingCallLogDetails = await CallLogModel.findOne({
-                where: { thirdPartyLogId: callLogId }
-            });
-
-            if (!existingCallLogDetails) {
-                return {
-                    callLogInfo: {
-                        subject: "",
-                        note: "",
-                        fullLogResponse: {}
-                    }
-                };
-            }
-
-            const contactId = existingCallLogDetails.contactId;
-
-            const getLogRes = await serviceTitanApiClient.get(
-                `${SERVICE_TITAN_CRM_URL}/${tenantId}/customers/${contactId}/notes`,
-                {
-                    headers: {
-                        Authorization: `Bearer ${auth}`,
-                        "ST-App-Key": stAppKey
-                    },
-                    _operation: 'getCallLog'
-                }
-            );
-
-            const targetLog = getLogRes.data.data.find(log => log.id == realId);
-
-            if (targetLog) {
-
-                const body = targetLog.text || "";
-                const normalized = body.replace(/\r\n/g, '\n');
-
-                const subjectMatch = normalized.match(/Subject:\s*(.*?)(?:\n|$)/);
-                subject = subjectMatch ? subjectMatch[1].trim() : '';
-
-                if (!subject || subject.toLowerCase().startsWith('direction:')) {
-                    subject = '';
-                }
-
-                const agentMatch = normalized.match(/Agent Notes:\s*([\s\S]*?)(?:\n[A-Za-z][^\n]*:|$)/);
-
-                if (agentMatch) {
-                    note = agentMatch[1].trim();
-                }
-
-                full_data = body;
-            }
+            full_data = body;
         }
 
     } catch (error) {
@@ -1537,7 +1143,7 @@ async function getCallLog({ user, callLogId }) {
 
     }
 
-    apiLog.logSuccess('ServiceTitan', 'getCallLog', { logId: callLogId, logType });
+    apiLog.logSuccess('ServiceTitan', 'getCallLog', { logId: callLogId });
 
     return {
         callLogInfo: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,10 @@ const servicenow = require('./connectors/servicenow');
 const serviceTitan = require('./connectors/servicetitan');
 const monday = require('./connectors/monday');
 const agencyzoom = require('./connectors/agencyzoom');
-const googleSheetsExtra = require('./connectors/googleSheets/extra.js');
+// No explicit extension: resolves to extra.ts from source (ts-jest) and to extra.js from the
+// compiled build. Hardcoding ".js" broke every test suite that loads this entry, because only
+// extra.ts exists in src/ after the TypeScript migration.
+const googleSheetsExtra = require('./connectors/googleSheets/extra');
 const logger = require('@app-connect/core/lib/logger');
 const adminCore = require('@app-connect/core/handlers/admin');
 const vinsolutions = /** @type {any} */ (require('./connectors/vinsolutions'));


### PR DESCRIPTION
1. Added ServiceTitan-style API logging in Monday connector — every API call is tagged with the calling function, parameters, and timing for easy debugging.

2. Fixed OAuth hostname resolution — hostname now comes from the Monday account the token was actually issued for (me.account.slug), not the extension's stale cached value.

3. Fixed recording/voicemail file uploads (were saving as .htm or failing with 401) — media links are unwrapped and tokenized download links used; recording also uploads on recording-sync in update call log.

4. Respect user's date-format setting in call/SMS logs, strip ** from AI notes, and SMS threads now jump to the top of updates with single-line spacing