### PR TITLE
Added a check for inserting Rc Account Id of existing customers in DB

### DIFF
--- a/src/adapters/servicenow-models/backfillRcAccountId.js
+++ b/src/adapters/servicenow-models/backfillRcAccountId.js
@@ -1,0 +1,92 @@
+const { Op } = require('sequelize');
+const { UserModel } = require('@app-connect/core/models/userModel');
+
+// One-time proactive back-fill of each company's RingCentral Account ID.
+//
+// Existing companies hold a dummy rcAccountId, so we cannot rely on the value being null.
+// The `isRcAccountId` flag is the source of truth: false/null means "still the dummy / not
+// yet real", true means "real value already set". We therefore select companies by the flag,
+// not by the rcAccountId value, and overwrite the dummy when we find a real id.
+//
+// The real, raw rcAccountId lives only in the core `users` table (captured at OAuth connect).
+// The ServiceNow `companies`/`customer` tables do not carry it, so we join across the two
+// databases in code, on `hostname` (the reliable key shared by both). For every not-yet-filled
+// company, we copy the value from any connected user on the same hostname that has one, and
+// mark the company filled. This fills every company that has at least one recently-connected
+// user, instead of waiting for that user's first contact search.
+//
+// Companies where every connected user is "genuinely old" (no stored rcAccountId anywhere)
+// cannot be filled here — there is no source value — and stay on the dummy until someone
+// reconnects.
+async function backfillCompanyRcAccountId(models) {
+    // Companies not yet filled with a real value (flag is null or false).
+    const pendingCompanies = await models.companies.findAll({
+        where: { isRcAccountId: { [Op.or]: [null, false] } },
+        attributes: ['id', 'hostname'],
+        raw: true
+    });
+
+    if (pendingCompanies.length === 0) {
+        return;
+    }
+
+    const hostnames = [...new Set(pendingCompanies.map((company) => company.hostname).filter(Boolean))];
+    if (hostnames.length === 0) {
+        return;
+    }
+
+    // Users (core DB) on those hostnames that carry a raw rcAccountId.
+    const users = await UserModel.findAll({
+        where: {
+            hostname: { [Op.in]: hostnames },
+            rcAccountId: { [Op.not]: null }
+        },
+        attributes: ['hostname', 'rcAccountId'],
+        raw: true
+    });
+
+    // hostname -> first non-empty rcAccountId found for it.
+    const rcAccountIdByHostname = new Map();
+    for (const user of users) {
+        if (user.rcAccountId && !rcAccountIdByHostname.has(user.hostname)) {
+            rcAccountIdByHostname.set(user.hostname, user.rcAccountId);
+        }
+    }
+
+    let filled = 0;
+    for (const company of pendingCompanies) {
+        const rcAccountId = rcAccountIdByHostname.get(company.hostname);
+        if (!rcAccountId) {
+            continue;
+        }
+        try {
+            await models.companies.update(
+                { rcAccountId, isRcAccountId: true },
+                { where: { id: company.id } }
+            );
+            filled++;
+        } catch (err) {
+            console.log(`[backfill] could not fill company "${company.hostname}":`, err?.message);
+        }
+    }
+
+    console.log(`[backfill] rcAccountId back-fill complete: filled ${filled} of ${pendingCompanies.length} pending companies`);
+}
+
+let backfillPromise = null;
+
+// Runs the back-fill once per app start. Never throws: on failure it logs and clears the
+// memory so a later start retries. Safe to run on every instance — it only touches companies
+// whose flag is still unset, so once everything is filled it is effectively a no-op.
+function runRcAccountIdBackfillOnce(models) {
+    if (!backfillPromise) {
+        backfillPromise = backfillCompanyRcAccountId(models).catch((err) => {
+            console.log('[backfill] failed; will retry on next start:', err?.message);
+            backfillPromise = null;
+        });
+    }
+    return backfillPromise;
+}
+
+exports.backfillCompanyRcAccountId = backfillCompanyRcAccountId;
+exports.runRcAccountIdBackfillOnce = runRcAccountIdBackfillOnce;

--- a/src/adapters/servicenow-models/companies.js
+++ b/src/adapters/servicenow-models/companies.js
@@ -71,6 +71,11 @@ module.exports = function(sequelize, DataTypes) {
       type: DataTypes.STRING(100),
       allowNull: true
     },
+    isRcAccountId: {
+      type: DataTypes.BOOLEAN,
+      allowNull: true,
+      defaultValue: false
+    },
     hashedRcAccountId: {
       type: DataTypes.STRING(255),
       allowNull: true

--- a/src/adapters/servicenow-models/migrate.js
+++ b/src/adapters/servicenow-models/migrate.js
@@ -1,0 +1,81 @@
+// Keeps the database in step with the models defined in code.
+//
+// For every model (table blueprint) it is given, it checks that each column defined in
+// code actually exists in the database. Any column that is missing gets created.
+//
+// It ONLY adds missing tables/columns. It never changes or deletes anything that already
+// exists, so it is safe to run against production data. This runs at start-up, so when a
+// new column is added in code it is created automatically, with no manual SQL needed in
+// each environment. Every step is wrapped so one problem column is logged and skipped
+// instead of stopping the whole app.
+async function ensureModelsSchema(sequelize, models) {
+    const queryInterface = sequelize.getQueryInterface();
+
+    for (const modelName of Object.keys(models)) {
+        const model = models[modelName];
+
+        // Skip anything that isn't a real Sequelize model (e.g. helper exports).
+        if (!model || typeof model.getTableName !== 'function') {
+            continue;
+        }
+
+        const tableName = model.getTableName();
+
+        let existingColumns;
+        try {
+            const description = await queryInterface.describeTable(tableName);
+            existingColumns = Object.keys(description).map((name) => name.toLowerCase());
+        } catch (err) {
+            // The table itself is missing — create it from the model. This only creates
+            // the table when it does not already exist; it never alters an existing one.
+            try {
+                await model.sync();
+                console.log(`[migration] created missing table "${tableName}"`);
+            } catch (createErr) {
+                console.log(`[migration] could not create table "${tableName}":`, createErr?.message);
+            }
+            continue;
+        }
+
+        const attributes = model.rawAttributes;
+        for (const attributeName of Object.keys(attributes)) {
+            const attribute = attributes[attributeName];
+            // The real database column name can differ from the code name via `field`.
+            const columnName = attribute.field || attributeName;
+
+            if (existingColumns.includes(columnName.toLowerCase())) {
+                continue;
+            }
+
+            try {
+                await queryInterface.addColumn(tableName, columnName, {
+                    type: attribute.type,
+                    allowNull: attribute.allowNull,
+                    defaultValue: attribute.defaultValue
+                });
+                console.log(`[migration] added missing column "${tableName}.${columnName}"`);
+            } catch (err) {
+                console.log(`[migration] could not add column "${tableName}.${columnName}":`, err?.message);
+            }
+        }
+    }
+}
+
+let schemaReadyPromise = null;
+
+// Runs the check once per app start and remembers the result, so it is not repeated on
+// every request. Anything that reads/writes these tables awaits this first, so the columns
+// are guaranteed to be there. It never throws: on failure it logs and clears the memory so
+// the next call tries again (behaving as before the check ran in the meantime).
+function ensureSchemaOnce(sequelize, models) {
+    if (!schemaReadyPromise) {
+        schemaReadyPromise = ensureModelsSchema(sequelize, models).catch((err) => {
+            console.log('[migration] schema check failed; will retry on next call:', err?.message);
+            schemaReadyPromise = null;
+        });
+    }
+    return schemaReadyPromise;
+}
+
+exports.ensureModelsSchema = ensureModelsSchema;
+exports.ensureSchemaOnce = ensureSchemaOnce;

--- a/src/adapters/servicenow/index.js
+++ b/src/adapters/servicenow/index.js
@@ -464,7 +464,19 @@ async function findContact({ user, authHeader, phoneNumber, overridingFormat, is
             }
         };
     }
-    
+
+    // Back-fill the RingCentral account id for existing companies once.
+    // Guard: only update when we actually have an rcAccountId on the logged-in user.
+    try {
+        const rcAccountId = user?.dataValues?.rcAccountId;
+        if (!companyData.isRcAccountId && rcAccountId) {
+            await companyData.update({ rcAccountId, isRcAccountId: true });
+            console.log("Company Value updated")
+        }
+    } catch (err) {
+        console.log('Failed to back-fill rcAccountId for company:', err?.message);
+    }
+
     let states = [];
     let interactionType = [];
     try {

--- a/src/adapters/servicenow/index.js
+++ b/src/adapters/servicenow/index.js
@@ -10,12 +10,15 @@ const Sequelize = require('sequelize');
 const { sequelize } = require('../servicenow-models/sequelize');
 const { raw } = require('mysql2');
 const { ensureSchemaOnce } = require('../servicenow-models/migrate');
+const { runRcAccountIdBackfillOnce } = require('../servicenow-models/backfillRcAccountId');
 const models = initModels(sequelize);
 // On boot, add any columns/tables that exist in the models but are missing in the database
 // (add-only, never changes existing data), so no manual SQL is needed per environment.
 // Kicked off here so it is usually done before the first request; functions that read these
 // tables also await ensureSchemaOnce as a guard in case a request arrives mid-migration.
-ensureSchemaOnce(sequelize, models);
+// Once the schema is ready, run the one-time proactive rcAccountId back-fill (fills companies
+// whose isRcAccountId flag is still unset from any connected user that has a real id).
+ensureSchemaOnce(sequelize, models).then(() => runRcAccountIdBackfillOnce(models));
 const { secondsToHoursMinutesSeconds } = require('@app-connect/core/lib/util');
 const fs = require("fs");
 const path = require("path");

--- a/src/adapters/servicenow/index.js
+++ b/src/adapters/servicenow/index.js
@@ -9,7 +9,13 @@ const { initModels } = require('../servicenow-models/init-models');
 const Sequelize = require('sequelize');
 const { sequelize } = require('../servicenow-models/sequelize');
 const { raw } = require('mysql2');
+const { ensureSchemaOnce } = require('../servicenow-models/migrate');
 const models = initModels(sequelize);
+// On boot, add any columns/tables that exist in the models but are missing in the database
+// (add-only, never changes existing data), so no manual SQL is needed per environment.
+// Kicked off here so it is usually done before the first request; functions that read these
+// tables also await ensureSchemaOnce as a guard in case a request arrives mid-migration.
+ensureSchemaOnce(sequelize, models);
 const { secondsToHoursMinutesSeconds } = require('@app-connect/core/lib/util');
 const fs = require("fs");
 const path = require("path");
@@ -92,6 +98,7 @@ async function getOauthInfo(requestData) {
     // }
     console.log("getOauthInfo requestData", requestData);
 
+    await ensureSchemaOnce(sequelize, models);
     const companyData = await models.companies.findOne({
         where: {
             hostname: requestData.hostname
@@ -161,6 +168,7 @@ async function getUserInfo({ authHeader, additionalInfo, hostname}) {
     // ------------------------------------------------------
     try {
 
+        await ensureSchemaOnce(sequelize, models);
         const getCompanyDetails = await models.companies.findOne({
             where: {
                 hostname: hostname
@@ -440,6 +448,7 @@ async function findContact({ user, authHeader, phoneNumber, overridingFormat, is
 
     console.log("hostname", hostname)
 
+    await ensureSchemaOnce(sequelize, models);
     const companyData = await models.companies.findOne({
         where: {
             hostname: hostname,
@@ -617,6 +626,7 @@ async function createCallLog({ user, contactInfo, authHeader, callLog, note, add
 
     const userInfo = await getHostname(user.dataValues.hostname);
 
+    await ensureSchemaOnce(sequelize, models);
     const { userDetailsPath }  = await models.companies.findOne({
         where: {
             hostname: userInfo.hostname,
@@ -931,6 +941,7 @@ async function createMessageLog({ user, contactInfo, authHeader, message, additi
     const instanceId = userInfo.instanceId;
     const hostname = userInfo.hostname;
 
+    await ensureSchemaOnce(sequelize, models);
     const { userDetailsPath }  = await models.companies.findOne({
         where: {
             hostname: hostname,
@@ -1151,6 +1162,7 @@ async function createContact({ user, authHeader, phoneNumber, newContactName, ne
     const instanceId = userInfo.instanceId;
     const hostname = userInfo.hostname;
 
+    await ensureSchemaOnce(sequelize, models);
     const companyData = await models.companies.findOne({
         where: {
             hostname: hostname,


### PR DESCRIPTION
1. Added a check for inserting Rc Account Id of existing customers in DB.
2. Added Migration code which will run and check if any column is missing in the database it will create that accordingly.
3. Backfills the companies.rcAccountId for existing ServiceNow companies that still hold a dummy value, keyed on the isRcAccountId flag rather than the value itself. Runs as a one-time proactive job at startup (copying each company's real id from a connected user on the same hostname), with a reactive fallback in findContact for anything missed.
