### PR TITLE
Add ServiceTitan job management: log calls and messages to customer jobs

### DIFF
--- a/src/connectors/servicetitan-core/jobs.ts
+++ b/src/connectors/servicetitan-core/jobs.ts
@@ -1,0 +1,500 @@
+// @ts-nocheck
+// ServiceTitan job management.
+//
+// A ServiceTitan customer's work is organised into jobs, and dispatchers and technicians read a
+// job's own notes rather than the customer's. So the call log form offers a Job dropdown: pick one
+// of the customer's open jobs and the call is written to that job's notes IN ADDITION to the
+// customer's, so the customer keeps a complete communication history either way.
+//
+// Everything job-related lives here — job/job-type lookup, option building, job creation, and the
+// job-note read/write helpers — so the connector's index.ts stays focused on call and message
+// logging. Nothing here imports the connector back: the caller passes in the resolved CRM base URL
+// and credentials, which keeps this module free of circular requires and testable on its own.
+
+const axios = require('axios');
+const moment = require('moment');
+const apiLog = require('../shared/apiLogger');
+const { trackAnalytics } = require('../shared/analytics');
+
+const serviceTitanApiClient = axios.create();
+apiLog.installErrorInterceptor(serviceTitanApiClient, 'ServiceTitan');
+
+// The statuses worth offering — a call is logged against work that is still open. ServiceTitan's
+// `jobStatus` filter takes ONE value (not a comma-separated list), so each status is its own request.
+const ACTIVE_JOB_STATUSES = ['Scheduled', 'Dispatched', 'InProgress', 'Hold'];
+
+const JOB_OPTION_NONE = 'none';
+const JOB_OPTION_CREATE_NEW = 'createNewJob';
+const JOB_OPTION_NONE_TITLE = 'None (log to customer notes only)';
+const JOB_OPTION_CREATE_NEW_TITLE = 'Create new job...';
+
+// A job note cannot be edited or removed once written, so an updated log necessarily appends a new
+// note and the job keeps every superseded version. This is a ServiceTitan limitation, not a gap
+// here: GET /jpm/v2/tenant/{t}/jobs/{id}/notes returns notes as
+//   { text, isPinned, createdById, createdOn, modifiedOn }
+// with no id of any kind, so there is nothing to address a PATCH or DELETE to. Verified against the
+// integration tenant on 2026-08-03. Do not add a delete-then-recreate pass — it cannot work.
+// The customer note is the log's system of record and IS rewritten cleanly on every update.
+
+// Job types are tenant-level and change rarely, but they are needed on every contact match to fill
+// the job type dropdown. Cache them briefly so contact lookup stays fast.
+const JOB_TYPE_CACHE_TTL_MS = 10 * 60 * 1000;
+const jobTypeCache = new Map();
+const jobTypeRequests = new Map();
+
+// ---------------------------------------------------------------------------
+// API bases and headers
+// ---------------------------------------------------------------------------
+
+// Customers live under ServiceTitan's crm/v2 area, but jobs live under jpm/v2, business units under
+// settings/v2 and campaigns under marketing/v2. All four share the tenant's API host, so derive them
+// from the one CRM base the connector already resolves rather than adding three more env vars that
+// could drift out of sync with it — and with the integration-tenant override it applies.
+function getApiBaseUrl(crmBaseUrl, area) {
+    const base = String(crmBaseUrl ?? '');
+    const derived = base.replace(/\/crm\/v2(?=\/tenant\b|\/?$)/, `/${area}/v2`);
+    if (derived === base) {
+        console.warn(`[ServiceTitan] cannot derive the ${area} API base from "${base}" — the configured CRM URI must contain /crm/v2. Job features will fail until it does.`);
+    }
+    return derived;
+}
+
+function getJpmBaseUrl(crmBaseUrl) {
+    return getApiBaseUrl(crmBaseUrl, 'jpm');
+}
+
+function stHeaders(auth, stAppKey, extraHeaders) {
+    return {
+        Authorization: `Bearer ${auth}`,
+        'ST-App-Key': stAppKey,
+        ...extraHeaders
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Settings
+// ---------------------------------------------------------------------------
+
+function isJobLoggingEnabled(user) {
+    return (user?.userSettings?.logCallToJob?.value ?? true) === true;
+}
+
+// Raising work from a phone call is a bigger commitment than filing a note against it, so creating
+// jobs is off unless an admin turns it on.
+function isJobCreationEnabled(user) {
+    return (user?.userSettings?.allowCreateJob?.value ?? false) === true;
+}
+
+// The job type an interaction falls back to when nobody picked a job — the case that matters most,
+// since automatic logging never shows a form for anyone to pick from.
+function getDefaultJobTypeName(user) {
+    return String(user?.userSettings?.defaultJobName?.value ?? '').trim();
+}
+
+// The default is typed by hand into a settings text field, so it is matched forgivingly: case and
+// spacing are ignored, the same leniency ServiceNow documents for its typed state/type defaults.
+function normalizeJobTypeName(name) {
+    return String(name ?? '').toLowerCase().replace(/\s+/g, '');
+}
+
+// ---------------------------------------------------------------------------
+// Lookups
+// ---------------------------------------------------------------------------
+
+async function fetchJobTypes({ crmBaseUrl, tenantId, auth, stAppKey }) {
+    const cached = jobTypeCache.get(tenantId);
+    if (cached && cached.expiresAt > Date.now()) {
+        return cached.jobTypes;
+    }
+    // Matching a contact can ask for job types twice at once — to name the customer's jobs and to
+    // fill the job type dropdown — so the in-flight request is shared as well as the result;
+    // otherwise a cold cache fires the same call twice on every contact match.
+    let inFlight = jobTypeRequests.get(tenantId);
+    if (!inFlight) {
+        const fetchJobTypesUrl = `${getJpmBaseUrl(crmBaseUrl)}/${tenantId}/job-types?active=true&pageSize=200`;
+        inFlight = serviceTitanApiClient
+            .get(fetchJobTypesUrl, { headers: stHeaders(auth, stAppKey), _operation: 'fetchJobTypes' })
+            .then(res => {
+                const jobTypes = (res.data?.data ?? []).map(jobType => ({ id: jobType.id, name: jobType.name }));
+                jobTypeCache.set(tenantId, { expiresAt: Date.now() + JOB_TYPE_CACHE_TTL_MS, jobTypes });
+                return jobTypes;
+            })
+            .finally(() => jobTypeRequests.delete(tenantId));
+        jobTypeRequests.set(tenantId, inFlight);
+    }
+    return inFlight;
+}
+
+async function fetchActiveJobs({ crmBaseUrl, tenantId, auth, stAppKey, customerId }) {
+    if (!customerId) return [];
+
+    const jpmBaseUrl = getJpmBaseUrl(crmBaseUrl);
+    // One status failing (a tenant that doesn't use Hold, say) must not cost us the others.
+    const responses = await Promise.all(ACTIVE_JOB_STATUSES.map(status =>
+        serviceTitanApiClient.get(
+            `${jpmBaseUrl}/${tenantId}/jobs?customerId=${customerId}&jobStatus=${status}&pageSize=50`,
+            { headers: stHeaders(auth, stAppKey), _operation: 'fetchActiveJobs' }
+        ).catch(err => {
+            console.warn(`[ServiceTitan] fetchActiveJobs: ${status} lookup failed:`, err?.response?.data || err.message);
+            return null;
+        })
+    ));
+
+    const jobs = [];
+    const seenIds = new Set();
+    for (const res of responses) {
+        for (const job of res?.data?.data ?? []) {
+            if (seenIds.has(job.id)) continue;
+            seenIds.add(job.id);
+            jobs.push(job);
+        }
+    }
+
+    // A job carries only jobTypeId; the agent needs the readable type name to tell jobs apart.
+    let jobTypeNames = new Map();
+    try {
+        jobTypeNames = new Map((await fetchJobTypes({ crmBaseUrl, tenantId, auth, stAppKey })).map(t => [t.id, t.name]));
+    } catch (err) {
+        console.warn('[ServiceTitan] fetchActiveJobs: job type lookup failed:', err?.response?.data || err.message);
+    }
+    for (const job of jobs) {
+        job.jobTypeName = jobTypeNames.get(job.jobTypeId) || 'Job';
+    }
+
+    return jobs;
+}
+
+// ---------------------------------------------------------------------------
+// Form options
+// ---------------------------------------------------------------------------
+
+function buildJobOptions({ jobs, allowCreate, defaultJobTypeName }) {
+    const options = [
+        // With a default job type configured, "no choice" is not the same as "no job" — so the first
+        // option says what leaving it alone will actually do rather than claiming customer-only.
+        defaultJobTypeName
+            ? {
+                const: JOB_OPTION_NONE,
+                title: `Default: ${defaultJobTypeName}`,
+                description: `Uses the customer's open ${defaultJobTypeName} job, or opens one`
+            }
+            : { const: JOB_OPTION_NONE, title: JOB_OPTION_NONE_TITLE },
+        ...jobs.map(job => ({
+            const: String(job.id),
+            title: `#${job.jobNumber || job.id} - ${job.jobTypeName}`,
+            description: job.jobStatus || job.status || ''
+        }))
+    ];
+    // "Create new job" goes last, after every existing job, so linking the job the caller is
+    // actually phoning about stays at the top of the list and raising new work is a deliberate
+    // scroll rather than a mis-click.
+    if (allowCreate) {
+        options.push({
+            const: JOB_OPTION_CREATE_NEW,
+            title: JOB_OPTION_CREATE_NEW_TITLE,
+            description: 'Pick the work in the Job type dropdown'
+        });
+    }
+    return options;
+}
+
+// The Job and Job type dropdowns are `contactDependent`, so their options have to travel back
+// attached to the matched contact. A job lookup problem must never cost us the contact match, so
+// every failure degrades to a customer-notes-only dropdown.
+async function buildJobAdditionalInfo({ user, crmBaseUrl, tenantId, auth, stAppKey, customerId, logPrefix }) {
+    if (!isJobLoggingEnabled(user)) {
+        return null;
+    }
+    const allowCreate = isJobCreationEnabled(user);
+    try {
+        const [jobs, jobTypes] = await Promise.all([
+            fetchActiveJobs({ crmBaseUrl, tenantId, auth, stAppKey, customerId }),
+            // Job types are only ever used to raise new work, so skip the lookup entirely when an
+            // admin has not enabled that.
+            allowCreate
+                ? fetchJobTypes({ crmBaseUrl, tenantId, auth, stAppKey }).catch(() => [])
+                : Promise.resolve([])
+        ]);
+        return {
+            associatedJob: buildJobOptions({ jobs, allowCreate, defaultJobTypeName: getDefaultJobTypeName(user) }),
+            newJobType: jobTypes.map(jobType => ({ const: String(jobType.id), title: jobType.name }))
+        };
+    } catch (err) {
+        console.warn(`${logPrefix} failed to load jobs for customer ${customerId}:`, err?.response?.data || err.message);
+        return {
+            associatedJob: [{ const: JOB_OPTION_NONE, title: JOB_OPTION_NONE_TITLE }],
+            newJobType: []
+        };
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Job creation
+// ---------------------------------------------------------------------------
+
+async function resolveNewJobLocationId({ crmBaseUrl, tenantId, auth, stAppKey, customerId }) {
+    const locationsUrl = `${crmBaseUrl}/${tenantId}/locations?customerId=${customerId}&active=true&pageSize=1`;
+    const res = await serviceTitanApiClient.get(
+        locationsUrl,
+        { headers: stHeaders(auth, stAppKey), _operation: 'createJob' }
+    );
+    return res.data?.data?.[0]?.id ?? null;
+}
+
+async function resolveNewJobBusinessUnitId({ user, crmBaseUrl, tenantId, auth, stAppKey, existingJobs }) {
+    const configured = String(user.userSettings?.newJobBusinessUnitId?.value ?? '').trim();
+    if (configured) return configured;
+    // Prefer the unit the customer's existing work already sits in, so the new job lands with the
+    // crew the caller is most likely phoning about.
+    const fromExistingJob = existingJobs?.find(job => job.businessUnitId)?.businessUnitId;
+    if (fromExistingJob) return fromExistingJob;
+
+    const businessUnitsUrl = `${getApiBaseUrl(crmBaseUrl, 'settings')}/${tenantId}/business-units?active=true&pageSize=1`;
+    const res = await serviceTitanApiClient.get(
+        businessUnitsUrl,
+        { headers: stHeaders(auth, stAppKey), _operation: 'createJob' }
+    );
+    return res.data?.data?.[0]?.id ?? null;
+}
+
+async function resolveNewJobCampaignId({ user, crmBaseUrl, tenantId, auth, stAppKey }) {
+    const configured = String(user.userSettings?.newJobCampaignId?.value ?? '').trim();
+    if (configured) return configured;
+
+    const campaignsUrl = `${getApiBaseUrl(crmBaseUrl, 'marketing')}/${tenantId}/campaigns?active=true&pageSize=1`;
+    const res = await serviceTitanApiClient.get(
+        campaignsUrl,
+        { headers: stHeaders(auth, stAppKey), _operation: 'createJob' }
+    );
+    return res.data?.data?.[0]?.id ?? null;
+}
+
+// ServiceTitan will not create a job without a business unit, job type, campaign, location and an
+// appointment window — far more than a call log form should ask an agent for mid-call. So the agent
+// picks only the job type, and the rest resolves from the connector's job-defaults settings, then
+// the customer's existing work, then the tenant's first active record.
+async function createJobForCustomer({ user, crmBaseUrl, tenantId, auth, stAppKey, customerId, jobTypeId, existingJobs, summary }) {
+    const [locationId, businessUnitId, campaignId] = await Promise.all([
+        resolveNewJobLocationId({ crmBaseUrl, tenantId, auth, stAppKey, customerId }),
+        resolveNewJobBusinessUnitId({ user, crmBaseUrl, tenantId, auth, stAppKey, existingJobs }),
+        // Campaign is the one field ServiceTitan sometimes accepts as absent, so a lookup failure
+        // is not fatal — try the create without it and let ServiceTitan be the judge.
+        resolveNewJobCampaignId({ user, crmBaseUrl, tenantId, auth, stAppKey }).catch(err => {
+            console.warn('[ServiceTitan] createJobForCustomer: campaign lookup failed:', err?.response?.data || err.message);
+            return null;
+        })
+    ]);
+
+    if (!locationId) {
+        throw new Error('the customer has no active service location');
+    }
+    if (!businessUnitId) {
+        throw new Error('no business unit could be resolved — set a default in the ServiceTitan job defaults settings');
+    }
+
+    const appointmentMinutes = Number(user.userSettings?.newJobAppointmentDuration?.value) || 60;
+    const appointmentStart = moment();
+    const payload = {
+        customerId: Number(customerId),
+        locationId: Number(locationId),
+        businessUnitId: Number(businessUnitId),
+        jobTypeId: Number(jobTypeId),
+        priority: user.userSettings?.newJobPriority?.value || 'Normal',
+        campaignId: campaignId == null ? undefined : Number(campaignId),
+        summary,
+        appointments: [{
+            start: appointmentStart.toISOString(),
+            end: appointmentStart.clone().add(appointmentMinutes, 'minutes').toISOString()
+        }]
+    };
+
+    const createJobUrl = `${getJpmBaseUrl(crmBaseUrl)}/${tenantId}/jobs`;
+    const res = await serviceTitanApiClient.post(
+        createJobUrl,
+        payload,
+        { headers: stHeaders(auth, stAppKey, { 'Content-Type': 'application/json' }), _operation: 'createJob' }
+    );
+
+    apiLog.logSuccess('ServiceTitan', 'createJob', { jobId: res.data?.id, customerId, jobTypeId, apiEndpoint: createJobUrl });
+    await trackAnalytics({ user, crm: 'ServiceTitan', event: 'jobCreated' });
+    return res.data;
+}
+
+// ---------------------------------------------------------------------------
+// Target resolution
+// ---------------------------------------------------------------------------
+
+// Applied when nobody picked a job. Automatic call logging is the reason this exists: it writes the
+// log with no form and therefore no selection, so without a default every auto-logged call would
+// land on the customer only, never on the work it was about.
+//
+// The setting holds a job TYPE name. An open job of that type is reused when the customer has one —
+// several calls about the same visit then collect on one job — and a new job of that type is opened
+// when they do not.
+async function resolveDefaultJob({ user, crmBaseUrl, tenantId, auth, stAppKey, customerId, newJobSummary }) {
+    const defaultJobTypeName = getDefaultJobTypeName(user);
+    if (!defaultJobTypeName) {
+        return { jobId: null };
+    }
+    const wanted = normalizeJobTypeName(defaultJobTypeName);
+
+    try {
+        const activeJobs = await fetchActiveJobs({ crmBaseUrl, tenantId, auth, stAppKey, customerId });
+        const openJob = activeJobs.find(job => normalizeJobTypeName(job.jobTypeName) === wanted);
+        if (openJob) {
+            return { jobId: openJob.id };
+        }
+
+        const jobType = (await fetchJobTypes({ crmBaseUrl, tenantId, auth, stAppKey }))
+            .find(type => normalizeJobTypeName(type.name) === wanted);
+        if (!jobType) {
+            // Worth a loud warning: the setting is free text, so a typo here silently costs every
+            // auto-logged call its job for as long as it goes unnoticed.
+            console.warn(`[ServiceTitan] resolveDefaultJob: no active job type matches the configured default job "${defaultJobTypeName}" — check the spelling in settings.`);
+            return { jobId: null, warning: `No job type called "${defaultJobTypeName}" exists, so it was logged to the customer only.` };
+        }
+
+        const job = await createJobForCustomer({
+            user, crmBaseUrl, tenantId, auth, stAppKey, customerId,
+            jobTypeId: jobType.id,
+            existingJobs: activeJobs,
+            summary: newJobSummary || 'Opened from a RingCentral interaction.'
+        });
+        return { jobId: job.id, createdJobNumber: job.jobNumber || job.id };
+    } catch (err) {
+        const detail = err?.response?.data?.title || err?.response?.data?.message || err.message;
+        console.warn('[ServiceTitan] resolveDefaultJob: could not resolve the default job:', err?.response?.data || err.message);
+        return { jobId: null, warning: `Could not use the default job (${detail}). It was logged to the customer only.` };
+    }
+}
+
+// Works out which job a log should additionally be written to. Never throws and never blocks the
+// log: any job problem returns a null job with a warning, because the call detail always reaches
+// the customer's notes regardless and losing it would be far worse than filing it one level up.
+async function resolveTargetJob({ user, crmBaseUrl, tenantId, auth, stAppKey, customerId, additionalSubmission, newJobSummary }) {
+    if (!isJobLoggingEnabled(user)) {
+        return { jobId: null };
+    }
+
+    // No pick covers both an agent leaving the dropdown alone and automatic logging, which submits
+    // nothing at all — the configured default (if any) decides for both.
+    const selected = additionalSubmission?.associatedJob;
+    if (!selected || selected === JOB_OPTION_NONE) {
+        return resolveDefaultJob({ user, crmBaseUrl, tenantId, auth, stAppKey, customerId, newJobSummary });
+    }
+
+    if (selected === JOB_OPTION_CREATE_NEW) {
+        if (!isJobCreationEnabled(user)) {
+            return { jobId: null, warning: 'Creating jobs is switched off, so it was logged to the customer only.' };
+        }
+        const jobTypeId = additionalSubmission?.newJobType;
+        if (!jobTypeId) {
+            return { jobId: null, warning: 'No job type was chosen, so it was logged to the customer only.' };
+        }
+        try {
+            const existingJobs = await fetchActiveJobs({ crmBaseUrl, tenantId, auth, stAppKey, customerId }).catch(() => []);
+            const job = await createJobForCustomer({
+                user, crmBaseUrl, tenantId, auth, stAppKey, customerId, jobTypeId, existingJobs,
+                summary: newJobSummary || 'Opened from a RingCentral interaction.'
+            });
+            return { jobId: job.id, createdJobNumber: job.jobNumber || job.id };
+        } catch (err) {
+            const detail = err?.response?.data?.title || err?.response?.data?.message || err.message;
+            console.warn('[ServiceTitan] resolveTargetJob: job creation failed:', err?.response?.data || err.message);
+            return { jobId: null, warning: `Could not create the job (${detail}). It was logged to the customer only.` };
+        }
+    }
+
+    // The dropdown options were cached when the contact matched, so the job may have closed since.
+    try {
+        const activeJobs = await fetchActiveJobs({ crmBaseUrl, tenantId, auth, stAppKey, customerId });
+        if (!activeJobs.some(job => String(job.id) === String(selected))) {
+            return { jobId: null, warning: 'That job is no longer active, so it was logged to the customer only.' };
+        }
+    } catch (err) {
+        console.warn('[ServiceTitan] resolveTargetJob: could not verify the selected job:', err?.response?.data || err.message);
+        return { jobId: null, warning: 'The selected job could not be verified, so it was logged to the customer only.' };
+    }
+
+    return { jobId: selected };
+}
+
+// ---------------------------------------------------------------------------
+// Job notes
+// ---------------------------------------------------------------------------
+
+async function postJobNote({ crmBaseUrl, tenantId, auth, stAppKey, jobId, text, operation }) {
+    return serviceTitanApiClient.post(
+        `${getJpmBaseUrl(crmBaseUrl)}/${tenantId}/jobs/${jobId}/notes`,
+        { text },
+        { headers: stHeaders(auth, stAppKey, { 'Content-Type': 'application/json' }), _operation: operation }
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Log ids
+//
+// A log id doubles as the ServiceTitan page path that "view log" opens:
+//   job log      ->  Job/Index/{jobId}     ->  https://<host>/#/Job/Index/2689328
+//   customer log ->  customer/{contactId}  ->  https://<host>/#/customer/2673343
+//
+// App Connect substitutes {logId} into ONE fixed `logPageUrl` template with no way to branch on the
+// kind of log, and the two ServiceTitan pages have different path shapes — so carrying the path in
+// the id is the only way the link can reach the right page. That leaves no room for the customer
+// note id, which is why the note is located by the call's session id instead (see the connector's
+// findCallLogNote). Nor is the id unique per call — several calls share a job — so nothing may look
+// a log up by it; getCallLog resolves through telephonySessionId, the CallLogModel primary key.
+// ---------------------------------------------------------------------------
+
+function buildJobLogId(jobId) {
+    return `Job/Index/${jobId}`;
+}
+
+function buildCustomerLogId(contactId) {
+    return `customer/${contactId}`;
+}
+
+function parseLogId(thirdPartyLogId) {
+    const raw = String(thirdPartyLogId ?? '');
+
+    const jobMatch = raw.match(/^Job\/Index\/(\d+)$/);
+    if (jobMatch) {
+        return { logType: 'job', jobId: jobMatch[1], legacyNoteId: null };
+    }
+    if (/^customer\/\d+$/.test(raw)) {
+        return { logType: 'note', jobId: null, legacyNoteId: null };
+    }
+
+    // Ids written before the path scheme: `{noteId}_note` and `{customerNoteId}_{jobId}_jobnote`.
+    // Their first segment is a real customer note id, so it still resolves a note directly.
+    const [first, second, third] = raw.split('_');
+    if (third === 'jobnote') {
+        return { logType: 'job', jobId: second, legacyNoteId: first };
+    }
+    return { logType: 'note', jobId: null, legacyNoteId: first || null };
+}
+
+module.exports = {
+    ACTIVE_JOB_STATUSES,
+    JOB_OPTION_NONE,
+    JOB_OPTION_CREATE_NEW,
+    getApiBaseUrl,
+    getJpmBaseUrl,
+    stHeaders,
+    isJobLoggingEnabled,
+    isJobCreationEnabled,
+    getDefaultJobTypeName,
+    resolveDefaultJob,
+    fetchJobTypes,
+    fetchActiveJobs,
+    buildJobOptions,
+    buildJobAdditionalInfo,
+    createJobForCustomer,
+    resolveTargetJob,
+    postJobNote,
+    buildJobLogId,
+    buildCustomerLogId,
+    parseLogId
+};
+
+export {};

--- a/src/connectors/servicetitan/index.ts
+++ b/src/connectors/servicetitan/index.ts
@@ -16,6 +16,7 @@ const { trackAnalytics } = require('../shared/analytics');
 const models = sequelize ? initModels(sequelize) : null;
 const licenseHelper = require('../shared/license');
 const apiLog = require('../shared/apiLogger');
+const jobs = require('../servicetitan-core/jobs');
 
 const serviceTitanApiClient = axios.create();
 
@@ -62,7 +63,6 @@ function getAccessTokenUrl(tenantId) {
     return isIntegrationTenant(tenantId) ? INTEGRATION_ACCESS_TOKEN_URI : process.env.SERVICE_TITAN_ACCESS_TOKEN_URI;
 }
 
-
 apiLog.installErrorInterceptor(serviceTitanApiClient, 'ServiceTitan');
 
 // Format a timestamp with the user's chosen date format from the extension settings
@@ -77,6 +77,30 @@ function formatDateTime({ user, time }) {
             : momentTime.utcOffset(Number(tz));
     }
     return momentTime.format(user?.userSettings?.logDateFormat?.value || 'YYYY-MM-DD hh:mm:ss A');
+}
+
+// The log id is the ServiceTitan page path (see jobs.parseLogId), so it no longer carries the
+// customer note id. The note is found by the call session id it records instead — that is stable
+// across every update of a call, where the note id changes each time the note is replaced.
+const CALL_SESSION_LINE = 'Call Session ID:';
+
+function findCallLogNote(notes, sessionId, legacyNoteId) {
+    const byRecency = [...(notes ?? [])].sort(
+        (a, b) => new Date(b.createdOn ?? 0).getTime() - new Date(a.createdOn ?? 0).getTime()
+    );
+    if (sessionId) {
+        const bySession = byRecency.find(note => String(note.text ?? '').includes(`${CALL_SESSION_LINE} ${sessionId}`));
+        if (bySession) return bySession;
+    }
+    // Logs written before the path scheme still carry a real note id in the log id.
+    return legacyNoteId ? (byRecency.find(note => String(note.id) === String(legacyNoteId)) ?? null) : null;
+}
+
+// Summary written onto a job raised from an interaction, so a dispatcher opening the job can see
+// where it came from.
+function newJobSummaryFor(interactionKind, direction) {
+    const directionPrefix = direction ? `${String(direction).toLowerCase()} ` : '';
+    return `Opened from a ${directionPrefix}RingCentral ${interactionKind}.`;
 }
 
 async function getLicenseStatus({ userId }) {
@@ -355,6 +379,15 @@ async function findContact({ user, phoneNumber, isExtension }) {
 
             rawPersonInfo['phoneNumber'] = phoneNumber;
             const contact = formatContact(rawPersonInfo);
+            contact.additionalInfo = await jobs.buildJobAdditionalInfo({
+                user,
+                crmBaseUrl: getCrmBaseUrl(tenantId),
+                tenantId,
+                auth,
+                stAppKey: user.dataValues.platformAdditionalInfo.st_app_key,
+                customerId: contact.id,
+                logPrefix: '[ServiceTitan] findContact:'
+            });
             matchedContactInfo.push(contact);
         }
     }
@@ -410,6 +443,15 @@ async function findContactWithName({ user, name }) {
                 const phone = rawPersonInfo.phones?.find(p => p.type === 'Primary')?.phone ?? '';
                 rawPersonInfo['phoneNumber'] = phone;
                 const contact = formatContact(rawPersonInfo);
+                contact.additionalInfo = await jobs.buildJobAdditionalInfo({
+                    user,
+                    crmBaseUrl: getCrmBaseUrl(tenantId),
+                    tenantId,
+                    auth,
+                    stAppKey,
+                    customerId: contact.id,
+                    logPrefix: '[ServiceTitan] findContactWithName:'
+                });
                 matchedContactInfo.push(contact);
             }
         }
@@ -631,6 +673,8 @@ function sanitizeNoteText(text) {
 }
 
 async function createCallLog({ user, contactInfo, callLog, note, aiNote, transcript, additionalSubmission }) {
+    console.log("Additional submission1: ", additionalSubmission)
+    console.log("Call Log details: ", callLog)
     const licenseError = await validateLicenseOrFail(user);
     if (licenseError) return licenseError;
 
@@ -681,8 +725,11 @@ async function createCallLog({ user, contactInfo, callLog, note, aiNote, transcr
         headerLines.push(`Duration: ${callLog.duration} sec`);
     }
 
-    if (callLog.sessionId && (user.userSettings?.addCallSessionId?.value ?? true)) {
-        headerLines.push(`Call Session ID: ${callLog.sessionId}`);
+    // Structural, not decorative: this line is how a later update or read finds this note again,
+    // now that the log id is the ServiceTitan page path. It is written unconditionally so a setting
+    // can never make a call log unfindable.
+    if (callLog.sessionId) {
+        headerLines.push(`${CALL_SESSION_LINE} ${callLog.sessionId}`);
     }
 
     const rcUserName = additionalSubmission?.rcUserName;
@@ -712,7 +759,18 @@ async function createCallLog({ user, contactInfo, callLog, note, aiNote, transcr
     if (optionalSections) noteText += `\n\n${optionalSections}`;
     if (footerLines.length > 0) noteText += `\n\n${footerLines.join("\n")}`;
 
-    // Always log to the customer-level note.
+    const targetJob = await jobs.resolveTargetJob({
+        user,
+        crmBaseUrl: getCrmBaseUrl(tenantId),
+        tenantId, auth, stAppKey,
+        customerId: contactInfo.id,
+        additionalSubmission,
+        newJobSummary: newJobSummaryFor('call', callLog?.direction)
+    });
+
+    // The customer's notes always get the call, so a customer's full communication history stays in
+    // one place regardless of which job each call was about. It is also written first because its
+    // response carries the only real note id ServiceTitan gives us.
     const createCallLogUrl = `${getCrmBaseUrl(tenantId)}/${tenantId}/customers/${contactInfo.id}/notes`;
     const addNoteRes = await serviceTitanApiClient.post(
         createCallLogUrl,
@@ -726,8 +784,24 @@ async function createCallLog({ user, contactInfo, callLog, note, aiNote, transcr
             _operation: 'createCallLog'
         }
     );
-    const logId = `${addNoteRes.data.id}_note`;
-    apiLog.logSuccess('ServiceTitan', 'createCallLog', { logId, contactId: contactInfo.id, apiEndpoint: createCallLogUrl });
+    const customerNoteId = addNoteRes.data.id;
+
+    let logId = jobs.buildCustomerLogId(contactInfo.id);
+    let placement = 'Call log created';
+
+    // A selected job additionally gets the call, filed where dispatchers and technicians read.
+    const { jobId, warning: jobNoteWarning } = await writeJobNote({
+        targetJob, tenantId, auth, stAppKey, customerNoteId, noteText, operation: 'createCallLog'
+    });
+    if (jobId) {
+        // The id points at the job so "view log" lands on the job page rather than the customer.
+        logId = jobs.buildJobLogId(jobId);
+        placement = targetJob.createdJobNumber
+            ? `Call log created on new job #${targetJob.createdJobNumber} and the customer`
+            : 'Call log created on the job and the customer';
+    }
+
+    apiLog.logSuccess('ServiceTitan', 'createCallLog', { logId, contactId: contactInfo.id, jobId: jobId ?? null, apiEndpoint: createCallLogUrl });
 
     // Write the number this call came in on into the CRM customer so a later lookup of it resolves
     // to this customer instead of prompting a name search.
@@ -736,13 +810,17 @@ async function createCallLog({ user, contactInfo, callLog, note, aiNote, transcr
 
     await trackAnalytics({ user, crm: 'ServiceTitan', event: 'callLogCreated', eventDate: callLog?.startTime });
 
+    // A job that could not be used is worth telling the agent about — the log still saved, just not
+    // everywhere they asked for it.
+    const warning = targetJob.warning ?? jobNoteWarning;
+
     return {
         logId,
         contactId: contactInfo.id,
         returnMessage: {
-            message: "Call log created",
-            messageType: "success",
-            ttl: 2000
+            message: warning ? `${placement}. ${warning}` : placement,
+            messageType: warning ? "warning" : "success",
+            ttl: warning ? 5000 : 2000
         }
     };
 }
@@ -760,7 +838,9 @@ async function updateCallLog({ user, existingCallLog, recordingLink, note, aiNot
 
     const contactId = existingCallLog.contactId;
 
-    const [realId] = existingCallLog.thirdPartyLogId.split("_");
+    const { jobId: currentJobId, legacyNoteId } = jobs.parseLogId(existingCallLog.thirdPartyLogId);
+    // The call session id is the handle on the customer note; the log id is a page path now.
+    const sessionId = existingCallLog.sessionId;
 
     let direction = "";
     let startTime = "";
@@ -780,9 +860,11 @@ async function updateCallLog({ user, existingCallLog, recordingLink, note, aiNot
     let oldTranscript = "";
 
     // ---------------- FETCH OLD DATA ----------------
+    // Every call is written to the customer's notes whether or not it is also on a job, so the
+    // customer note is the log's system of record and the previous content always comes from there.
     let body = "";
     const getLogRes = await serviceTitanApiClient.get(
-        `${getCrmBaseUrl(tenantId)}/${tenantId}/customers/${contactId}/notes`,
+        `${getCrmBaseUrl(tenantId)}/${tenantId}/customers/${contactId}/notes?pageSize=100`,
         {
             headers: {
                 Authorization: `Bearer ${auth}`,
@@ -792,7 +874,10 @@ async function updateCallLog({ user, existingCallLog, recordingLink, note, aiNot
         }
     );
 
-    const targetLog = getLogRes.data.data.find(log => log.id == realId);
+    const targetLog = findCallLogNote(getLogRes.data?.data, sessionId, legacyNoteId);
+    // The note actually read is the one replaced below, so a stale or missing id cannot delete
+    // somebody else's note.
+    const previousNoteId = targetLog?.id ?? null;
 
     if (targetLog) {
         body = targetLog.text || "";
@@ -881,8 +966,9 @@ async function updateCallLog({ user, existingCallLog, recordingLink, note, aiNot
     if (duration && (user.userSettings?.addCallLogDuration?.value ?? true)) {
         headerLines.push(`Duration: ${duration} sec`);
     }
-    if (callSessionId && (user.userSettings?.addCallSessionId?.value ?? true)) {
-        headerLines.push(`Call Session ID: ${callSessionId}`);
+    // Carried forward for the same reason it is written on create — see createCallLog.
+    if (callSessionId) {
+        headerLines.push(`${CALL_SESSION_LINE} ${callSessionId}`);
     }
     if (rcUsername && (user.userSettings?.addRingCentralUserName?.value ?? true)) {
         headerLines.push(`RingCentral Username: ${rcUsername}`);
@@ -909,7 +995,13 @@ async function updateCallLog({ user, existingCallLog, recordingLink, note, aiNot
 
     let newLogId;
 
-    // ---------------- UPDATE NOTE ----------------
+    // ---------------- UPDATE NOTES ----------------
+
+    // The job is settled when the log is created and never changes afterwards. The edit form still
+    // submits the Job dropdown, but acting on it would file the update against a different job and
+    // strand the original — which would still show a call whose latest version lives elsewhere. So
+    // updates always go to the job the log was created against, and to no other.
+    const targetJob = { jobId: currentJobId };
 
     // ServiceTitan customer notes have no in-place update endpoint, so an edit is a
     // create-then-delete: post the replacement note, then delete the original so we don't
@@ -928,21 +1020,27 @@ async function updateCallLog({ user, existingCallLog, recordingLink, note, aiNot
         }
     );
 
-    newLogId = `${addNoteRes.data.id}_note`;
+    const newCustomerNoteId = addNoteRes.data.id;
 
-    if (realId && String(addNoteRes.data.id) !== String(realId)) {
+    if (previousNoteId && String(newCustomerNoteId) !== String(previousNoteId)) {
         try {
             await serviceTitanApiClient.delete(
-                `${getCrmBaseUrl(tenantId)}/${tenantId}/customers/${contactId}/notes/${realId}`,
+                `${getCrmBaseUrl(tenantId)}/${tenantId}/customers/${contactId}/notes/${previousNoteId}`,
                 {
                     headers: { Authorization: `Bearer ${auth}`, "ST-App-Key": stAppKey },
                     _operation: 'updateCallLog'
                 }
             );
         } catch (e) {
-            console.warn('[ServiceTitan][updateCallLog] could not delete the old note — a duplicate may remain', { oldNoteId: realId, status: e?.response?.status, message: e?.message });
+            console.warn('[ServiceTitan][updateCallLog] could not delete the old note — a duplicate may remain', { oldNoteId: previousNoteId, status: e?.response?.status, message: e?.message });
         }
     }
+
+    const { jobId, warning: jobNoteWarning } = await writeJobNote({
+        targetJob, tenantId, auth, stAppKey, customerNoteId: newCustomerNoteId, noteText, operation: 'updateCallLog'
+    });
+    // The id is a page path, so it does not change as the note behind it is replaced.
+    newLogId = jobId ? jobs.buildJobLogId(jobId) : jobs.buildCustomerLogId(contactId);
 
     const logID_db = await CallLogModel.findOne({
         where: {
@@ -956,16 +1054,18 @@ async function updateCallLog({ user, existingCallLog, recordingLink, note, aiNot
         await logID_db.save();
     }
 
-    apiLog.logSuccess('ServiceTitan', 'updateCallLog', { logId: newLogId, contactId });
+    apiLog.logSuccess('ServiceTitan', 'updateCallLog', { logId: newLogId, contactId, jobId: jobId ?? null });
 
     await trackAnalytics({ user, crm: 'ServiceTitan', event: 'callLogUpdated' });
+
+    const updatePlacement = jobId ? 'Call log updated on the job and the customer' : 'Call log updated';
 
     return {
         logId: newLogId,
         returnMessage: {
-            message: "Call log updated",
-            messageType: "success",
-            ttl: 2000
+            message: jobNoteWarning ? `${updatePlacement}. ${jobNoteWarning}` : updatePlacement,
+            messageType: jobNoteWarning ? "warning" : "success",
+            ttl: jobNoteWarning ? 5000 : 2000
         }
     };
 }
@@ -980,7 +1080,89 @@ async function upsertCallDisposition({ user, existingCallLog, authHeader, dispos
     };
 }
 
-async function createMessageLog({ user, contactInfo, message, recordingLink, faxDocLink }) {
+// An SMS thread is found by its own content rather than by the stored log id.
+//
+// ServiceTitan has no in-place note update, so every appended message replaces the note and changes
+// its id. Core does not carry that new id forward: on the update path it stamps each message's row
+// with the id as it was BEFORE the update (handlers/log.ts) and writes one row per message, all
+// sharing a conversationLogId. Its unordered `findOne` then hands us whichever of those rows it
+// likes — often one holding a note id that has since been replaced and deleted. Looking that id up
+// finds nothing, and the thread silently restarts as a one-message note.
+//
+// So the id is not trusted. The thread is the newest note on the customer that this connector wrote
+// for this counterparty, which stays correct no matter which row core passes in.
+const CONVERSATION_HEADER = 'Conversation';
+
+// The number is in the header because it both identifies the thread for the lookup below and tells
+// a reader which number the exchange was with — a customer can have more than one.
+function buildConversationHeader(counterpartyNumber) {
+    return counterpartyNumber
+        ? `${CONVERSATION_HEADER} with ${counterpartyNumber}:`
+        : `${CONVERSATION_HEADER}:`;
+}
+
+// Matches both header forms so a thread started before the number was recorded still continues.
+const CONVERSATION_BODY = /Conversation(?: with [^:\n]*)?:\s*([\s\S]*)/;
+
+// Picks the thread note to continue: the most recent one for this counterparty, falling back to an
+// un-numbered thread note when none carries the number yet.
+function findConversationNote(notes, counterpartyNumber) {
+    const byRecency = [...(notes ?? [])].sort(
+        (a, b) => new Date(b.createdOn ?? 0).getTime() - new Date(a.createdOn ?? 0).getTime()
+    );
+    const header = buildConversationHeader(counterpartyNumber);
+    return byRecency.find(note => String(note.text ?? '').trimStart().startsWith(header))
+        ?? byRecency.find(note => String(note.text ?? '').trimStart().startsWith(`${CONVERSATION_HEADER}:`))
+        ?? null;
+}
+
+// An SMS thread is rebuilt into a single note on every message, so it is capped and restarted
+// rather than growing without limit. The overlap repeats the tail of the old thread at the top of
+// the new note so the new one does not open mid-conversation.
+const MAX_THREAD_MESSAGES = 10;
+const THREAD_OVERLAP_MESSAGES = 1;
+// Backstop for threads whose messages are long enough to outgrow a note before hitting the count.
+const MAX_NOTE_SIZE = 30000;
+
+// Each message starts with a bracketed timestamp: "[03/08/2026 10:00:00 AM] Jane Smith: text".
+const CONVERSATION_MESSAGE_LINE = /^\[[^\]]+\]\s+[^:]+:/;
+
+// Splits a stored conversation back into messages. A text can itself contain line breaks, so the
+// split is on the timestamped line that opens each message rather than on every newline —
+// counting raw lines would restart threads early and truncate multi-line texts on restart.
+function splitConversationMessages(conversation) {
+    const messages = [];
+    for (const line of String(conversation ?? '').split('\n')) {
+        if (CONVERSATION_MESSAGE_LINE.test(line)) {
+            messages.push(line);
+        } else if (messages.length > 0) {
+            messages[messages.length - 1] += `\n${line}`;
+        }
+    }
+    return messages;
+}
+
+// Mirrors the job note the call log path writes. Returns the job actually written to, or a warning
+// when it could not be — the interaction is already safe on the customer either way, so a job note
+// failure is never worth failing the log over.
+async function writeJobNote({ targetJob, tenantId, auth, stAppKey, customerNoteId, noteText, operation }) {
+    if (!targetJob.jobId) return { jobId: null };
+    try {
+        await jobs.postJobNote({
+            crmBaseUrl: getCrmBaseUrl(tenantId),
+            tenantId, auth, stAppKey,
+            jobId: targetJob.jobId,
+            text: noteText,
+            operation
+        });
+        return { jobId: targetJob.jobId };
+    } catch (err) {
+        console.warn(`[ServiceTitan][${operation}] could not write the job note:`, err?.response?.data || err.message);
+        return { jobId: null, warning: 'It could not be written to the job, so it is on the customer notes only.' };
+    }
+}
+
+async function createMessageLog({ user, contactInfo, message, recordingLink, faxDocLink, additionalSubmission }) {
     const licenseError = await validateLicenseOrFail(user);
     if (licenseError) return licenseError;
 
@@ -1006,8 +1188,10 @@ async function createMessageLog({ user, contactInfo, message, recordingLink, fax
         const line =
             `[${formatDateTime({ user, time: message.creationTime })}] ${direction}: ${message.subject}`;
 
+        // The header carries the counterparty number so follow-up messages can find this thread
+        // again — see findConversationNote.
         noteText = `
-Conversation:
+${buildConversationHeader(phoneWriteback.resolveCounterpartyNumber({ message }))}
 ${line}
 `.trim();
 
@@ -1030,6 +1214,17 @@ ${faxDocLink}
 `.trim();
     }
 
+    const targetJob = await jobs.resolveTargetJob({
+        user,
+        crmBaseUrl: getCrmBaseUrl(tenantId),
+        tenantId, auth, stAppKey,
+        customerId: contactId,
+        additionalSubmission,
+        newJobSummary: newJobSummaryFor(messageType.toLowerCase(), message?.direction)
+    });
+
+    // As with calls, the customer's notes always get the message and are written first — their
+    // response carries the only real note id ServiceTitan returns.
     const createMessageLogUrl = `${getCrmBaseUrl(tenantId)}/${tenantId}/customers/${contactId}/notes`;
     const addLogRes = await serviceTitanApiClient.post(
         createMessageLogUrl,
@@ -1043,26 +1238,42 @@ ${faxDocLink}
             _operation: 'createMessageLog'
         }
     );
+    const customerNoteId = addLogRes.data.id;
 
-    apiLog.logSuccess('ServiceTitan', 'createMessageLog', { logId: addLogRes.data.id, contactId, apiEndpoint: createMessageLogUrl });
+    // A message log with no job keeps its bare numeric id, exactly as before this feature — only a
+    // job-linked log takes the suffixed form.
+    let logId = jobs.buildCustomerLogId(contactId);
+    let placement = 'Message logged as a note';
+    const { jobId, warning } = await writeJobNote({
+        targetJob, tenantId, auth, stAppKey, customerNoteId, noteText, operation: 'createMessageLog'
+    });
+    if (jobId) {
+        logId = jobs.buildJobLogId(jobId);
+        placement = targetJob.createdJobNumber
+            ? `Message logged on new job #${targetJob.createdJobNumber} and the customer`
+            : 'Message logged on the job and the customer';
+    }
+
+    apiLog.logSuccess('ServiceTitan', 'createMessageLog', { logId, contactId, jobId: jobId ?? null, apiEndpoint: createMessageLogUrl });
 
     // Same write-back as createCallLog: append the number this message came in on to the CRM customer.
     const receivedNumber = phoneWriteback.resolveCounterpartyNumber({ message });
     await appendContactNumberIfNew({ user, contactInfo, receivedNumber, auth, tenantId, stAppKey, logPrefix: '[ServiceTitan] createMessageLog:' });
     await trackAnalytics({ user, crm: 'ServiceTitan', event: 'messageLogCreated', eventDate: message?.creationTime });
 
+    const messageWarning = targetJob.warning ?? warning;
     return {
-        logId: addLogRes.data.id,
+        logId,
         contactId,
         returnMessage: {
-            message: "Message logged as a note",
-            messageType: "success",
-            ttl: 1000
+            message: messageWarning ? `${placement}. ${messageWarning}` : placement,
+            messageType: messageWarning ? "warning" : "success",
+            ttl: messageWarning ? 5000 : 1000
         }
     };
 }
 
-async function updateMessageLog({ user, contactInfo, existingMessageLog, message, recordingLink, faxDocLink }) {
+async function updateMessageLog({ user, contactInfo, existingMessageLog, message, recordingLink, faxDocLink, additionalSubmission }) {
     const licenseError = await validateLicenseOrFail(user);
     if (licenseError) return licenseError;
 
@@ -1073,17 +1284,25 @@ async function updateMessageLog({ user, contactInfo, existingMessageLog, message
     const stAppKey = user.dataValues.platformAdditionalInfo.st_app_key;
 
     const contactId = contactInfo.id;
-    const noteId = existingMessageLog.thirdPartyLogId;
+    // Message logs predate job support and stored a bare note id; parseLogId reads both that and the
+    // job-linked `{customerNoteId}_{jobId}_jobnote` form.
+    const { jobId: currentJobId, legacyNoteId } = jobs.parseLogId(existingMessageLog.thirdPartyLogId);
 
     const messageType = recordingLink ? 'Voicemail' : (faxDocLink ? 'Fax' : 'SMS');
 
     let noteText = "";
+    // The replacement note normally carries the whole conversation forward, making the note it
+    // replaces redundant. The one exception is an SMS thread restart — see below.
+    let supersedesPreviousNote = true;
+    // The note this update replaces. Resolved from the thread's own content rather than the stored
+    // log id — core hands back ids of notes that have since been replaced and deleted.
+    let previousNoteId = legacyNoteId;
 
     // ---------------- SMS CASE ----------------
     if (messageType === "SMS") {
 
         const getLogRes = await serviceTitanApiClient.get(
-            `${getCrmBaseUrl(tenantId)}/${tenantId}/customers/${contactId}/notes`,
+            `${getCrmBaseUrl(tenantId)}/${tenantId}/customers/${contactId}/notes?pageSize=100`,
             {
                 headers: {
                     Authorization: `Bearer ${auth}`,
@@ -1093,12 +1312,14 @@ async function updateMessageLog({ user, contactInfo, existingMessageLog, message
             }
         );
 
-        const targetLog = getLogRes.data.data.find(log => log.id == noteId);
+        const counterpartyNumber = phoneWriteback.resolveCounterpartyNumber({ message });
+        const targetLog = findConversationNote(getLogRes.data?.data, counterpartyNumber);
+        previousNoteId = targetLog?.id ?? null;
 
         let previousConversation = "";
 
         if (targetLog?.text) {
-            const match = targetLog.text.match(/Conversation:\s*([\s\S]*)/);
+            const match = targetLog.text.match(CONVERSATION_BODY);
             if (match) {
                 previousConversation = match[1].trim();
             }
@@ -1117,25 +1338,30 @@ async function updateMessageLog({ user, contactInfo, existingMessageLog, message
                 ? `${previousConversation}\n${newLine}`
                 : newLine;
 
-        const MAX_NOTE_SIZE = 30000;
+        const previousMessages = splitConversationMessages(previousConversation);
 
-        if (updatedConversation.length > MAX_NOTE_SIZE) {
+        // The note is capped by message count so a thread breaks at a predictable point. The size
+        // cap stays as a backstop: ten unusually long texts could still outgrow a ServiceTitan
+        // note, and a rejected note would lose the message outright.
+        if (previousMessages.length >= MAX_THREAD_MESSAGES || updatedConversation.length > MAX_NOTE_SIZE) {
 
-            const lines = previousConversation.trim().split("\n");
-            const lastMessage = lines[lines.length - 1] || "";
-
+            // Carry the tail of the old thread into the new note so it does not open without context.
             const newThreadConversation =
-                `${lastMessage}\n${newLine}`;
+                [...previousMessages.slice(-THREAD_OVERLAP_MESSAGES), newLine].join("\n");
 
             noteText = `
-Conversation:
+${buildConversationHeader(counterpartyNumber)}
 ${newThreadConversation}
 `.trim();
+
+            // The thread has been restarted rather than carried forward, so the previous note is
+            // the only copy of the conversation up to this point — it must be kept as history.
+            supersedesPreviousNote = false;
 
         } else {
 
             noteText = `
-Conversation:
+${buildConversationHeader(counterpartyNumber)}
 ${updatedConversation}
 `.trim();
         }
@@ -1164,6 +1390,10 @@ ${faxDocLink}
 `.trim();
     }
 
+    // As with call logs, the job is settled when the thread is first logged. Later messages continue
+    // on that job and are never re-filed against a different one.
+    const targetJob = { jobId: currentJobId };
+
     const updateMessageLogUrl = `${getCrmBaseUrl(tenantId)}/${tenantId}/customers/${contactId}/notes`;
     const addLogRes = await serviceTitanApiClient.post(
         updateMessageLogUrl,
@@ -1177,6 +1407,32 @@ ${faxDocLink}
             _operation: 'updateMessageLog'
         }
     );
+    const newCustomerNoteId = addLogRes.data.id;
+
+    // The replacement note carries the whole conversation, so the one it supersedes is a strictly
+    // shorter copy of it — remove it rather than leaving a note per message on the customer. Create
+    // first, so a failed delete costs a duplicate and never the conversation itself.
+    if (supersedesPreviousNote && previousNoteId && String(newCustomerNoteId) !== String(previousNoteId)) {
+        try {
+            await serviceTitanApiClient.delete(
+                `${updateMessageLogUrl}/${previousNoteId}`,
+                {
+                    headers: { Authorization: `Bearer ${auth}`, "ST-App-Key": stAppKey },
+                    _operation: 'updateMessageLog'
+                }
+            );
+        } catch (e) {
+            console.warn('[ServiceTitan][updateMessageLog] could not delete the superseded note — a duplicate may remain', { oldNoteId: previousNoteId, status: e?.response?.status, message: e?.message });
+        }
+    }
+
+    let newLogId = jobs.buildCustomerLogId(contactId);
+    const { jobId, warning } = await writeJobNote({
+        targetJob, tenantId, auth, stAppKey, customerNoteId: newCustomerNoteId, noteText, operation: 'updateMessageLog'
+    });
+    if (jobId) {
+        newLogId = jobs.buildJobLogId(jobId);
+    }
 
     const messageLogID_db = await MessageLogModel.findOne({
         where: {
@@ -1185,32 +1441,34 @@ ${faxDocLink}
     });
 
     if (messageLogID_db) {
-        messageLogID_db.thirdPartyLogId = addLogRes.data.id;
+        messageLogID_db.thirdPartyLogId = newLogId;
         await messageLogID_db.save();
     }
 
-    apiLog.logSuccess('ServiceTitan', 'updateMessageLog', { logId: addLogRes.data.id, contactId, apiEndpoint: updateMessageLogUrl });
+    apiLog.logSuccess('ServiceTitan', 'updateMessageLog', { logId: newLogId, contactId, jobId: jobId ?? null, apiEndpoint: updateMessageLogUrl });
 
 
     await trackAnalytics({ user, crm: 'ServiceTitan', event: 'messageLogUpdated' });
 
     return {
-        logId: addLogRes.data.id,
+        logId: newLogId,
         returnMessage: {
-            message: "Message log updated",
-            messageType: "success",
-            ttl: 1000
+            message: warning
+                ? `Message log updated. ${warning}`
+                : (jobId ? 'Message log updated on the job and the customer' : 'Message log updated'),
+            messageType: warning ? "warning" : "success",
+            ttl: warning ? 5000 : 1000
         }
     };
 }
-async function getCallLog({ user, callLogId }) {
+async function getCallLog({ user, callLogId, telephonySessionId, contactId }) {
     console.log(user.hostname, "hostname in getCallLog")
     const licenseError = await validateLicenseOrFail(user);
     if (licenseError) return licenseError;
 
     apiLog.logStart('ServiceTitan', 'getCallLog', { logId: callLogId });
 
-    const [realId] = callLogId.split("_");
+    const { legacyNoteId } = jobs.parseLogId(callLogId);
 
     const auth = await getRefreshedAuthToken(user);
     const tenantId = user.dataValues.platformAdditionalInfo.tenant;
@@ -1222,9 +1480,12 @@ async function getCallLog({ user, callLogId }) {
 
     try {
 
-        const existingCallLogDetails = await CallLogModel.findOne({
-            where: { thirdPartyLogId: callLogId }
-        });
+        // Several calls can share a log id now that it is a page path (every call on one job reads
+        // `Job/Index/{jobId}`), so the log is resolved by telephonySessionId — CallLogModel's
+        // primary key — rather than by the log id, which would match an arbitrary one of them.
+        const existingCallLogDetails = telephonySessionId
+            ? await CallLogModel.findByPk(telephonySessionId)
+            : await CallLogModel.findOne({ where: { thirdPartyLogId: callLogId } });
 
         if (!existingCallLogDetails) {
             return {
@@ -1236,10 +1497,13 @@ async function getCallLog({ user, callLogId }) {
             };
         }
 
-        const contactId = existingCallLogDetails.contactId;
+        const resolvedContactId = contactId ?? existingCallLogDetails.contactId;
 
+        // Read from the customer note: it holds the same content as the job note and, unlike a job
+        // note, it can be located and re-read.
+        let rawBody = null;
         const getLogRes = await serviceTitanApiClient.get(
-            `${getCrmBaseUrl(tenantId)}/${tenantId}/customers/${contactId}/notes`,
+            `${getCrmBaseUrl(tenantId)}/${tenantId}/customers/${resolvedContactId}/notes?pageSize=100`,
             {
                 headers: {
                     Authorization: `Bearer ${auth}`,
@@ -1249,11 +1513,14 @@ async function getCallLog({ user, callLogId }) {
             }
         );
 
-        const targetLog = getLogRes.data.data.find(log => log.id == realId);
-
+        const targetLog = findCallLogNote(getLogRes.data?.data, existingCallLogDetails.sessionId, legacyNoteId);
         if (targetLog) {
+            rawBody = targetLog.text || "";
+        }
 
-            const body = targetLog.text || "";
+        if (rawBody !== null) {
+
+            const body = rawBody;
             const normalized = body.replace(/\r\n/g, '\n');
 
             const subjectMatch = normalized.match(/Subject:\s*(.*?)(?:\n|$)/);

--- a/src/connectors/servicetitan/index.ts
+++ b/src/connectors/servicetitan/index.ts
@@ -673,8 +673,6 @@ function sanitizeNoteText(text) {
 }
 
 async function createCallLog({ user, contactInfo, callLog, note, aiNote, transcript, additionalSubmission }) {
-    console.log("Additional submission1: ", additionalSubmission)
-    console.log("Call Log details: ", callLog)
     const licenseError = await validateLicenseOrFail(user);
     if (licenseError) return licenseError;
 
@@ -1462,7 +1460,6 @@ ${faxDocLink}
     };
 }
 async function getCallLog({ user, callLogId, telephonySessionId, contactId }) {
-    console.log(user.hostname, "hostname in getCallLog")
     const licenseError = await validateLicenseOrFail(user);
     if (licenseError) return licenseError;
 

--- a/src/connectors/servicetitan/manifest.json
+++ b/src/connectors/servicetitan/manifest.json
@@ -87,7 +87,7 @@
                     "scope": ""
                 }
             },
-            "canOpenLogPage": false,
+            "canOpenLogPage": true,
             "contactTypes": [
                 {
                     "display": "Customer",
@@ -105,7 +105,7 @@
                 }
             },
             "contactPageUrl": "https://integration.servicetitan.com/#/customer/{contactId}",
-            "logPageUrl": "https://integration.servicetitan.com/#/customer/{contactId}",
+            "logPageUrl": "https://integration.servicetitan.com/#/{logId}",
             "callPopUrl": "https://integration.servicetitan.com/#/customer/{contactId}",
             "settings": [
                 {
@@ -156,6 +156,81 @@
                             "defaultValue": true
                         }
                     ]
+                },
+                {
+                    "id": "jobManagement",
+                    "type": "section",
+                    "name": "Job management",
+                    "items": [
+                        {
+                            "id": "logCallToJob",
+                            "type": "boolean",
+                            "name": "Log calls to jobs",
+                            "description": "Show a Job dropdown when logging a call, so the call can be written to one of the customer's open jobs as well as their customer notes.",
+                            "defaultValue": true
+                        },
+                        {
+                            "id": "allowCreateJob",
+                            "type": "boolean",
+                            "name": "Can create a new job",
+                            "description": "Add a \"Create new job...\" entry to the Job dropdown and populate the Job type dropdown, so a call can raise new work for the customer.",
+                            "defaultValue": false
+                        },
+                        {
+                            "id": "defaultJobName",
+                            "type": "inputField",
+                            "name": "Default job",
+                            "description": "Job type used when no job is picked, including every automatically logged call. The customer's open job of this type is reused, or a new one is opened. Leave blank to log those to the customer only.",
+                            "placeholder": "e.g. Service Call"
+                        },
+                        {
+                            "id": "defaultJobNameMatchWarning",
+                            "type": "warning",
+                            "name": "Info: default job matching",
+                            "value": "The default job must name a job type that exists in ServiceTitan. Matching ignores case and spaces."
+                        }
+                    ]
+                },
+                {
+                    "id": "jobDefaults",
+                    "type": "section",
+                    "name": "New job defaults",
+                    "visibleToUsers": false,
+                    "items": [
+                        {
+                            "id": "newJobBusinessUnitId",
+                            "type": "inputField",
+                            "name": "Business unit ID",
+                            "description": "Business unit assigned to jobs created from a call. Leave blank to reuse the business unit of the customer's existing work, falling back to the tenant's first active business unit."
+                        },
+                        {
+                            "id": "newJobCampaignId",
+                            "type": "inputField",
+                            "name": "Campaign ID",
+                            "description": "Campaign assigned to jobs created from a call. Leave blank to use the tenant's first active campaign."
+                        },
+                        {
+                            "id": "newJobPriority",
+                            "type": "option",
+                            "name": "Priority",
+                            "description": "Priority assigned to jobs created from a call.",
+                            "options": [
+                                { "id": "Low", "name": "Low" },
+                                { "id": "Normal", "name": "Normal" },
+                                { "id": "High", "name": "High" },
+                                { "id": "Urgent", "name": "Urgent" }
+                            ],
+                            "defaultValue": "Normal"
+                        },
+                        {
+                            "id": "newJobAppointmentDuration",
+                            "type": "inputField",
+                            "name": "Appointment length (minutes)",
+                            "description": "Length of the initial appointment booked on a job created from a call. It starts at the time the call is logged.",
+                            "placeholder": "60",
+                            "defaultValue": "60"
+                        }
+                    ]
                 }
             ],
             "page": {
@@ -163,20 +238,40 @@
                 "callLog": {
                     "additionalFields": [
                         {
-                            "const": "associatedDeal",
-                            "title": "Deals",
+                            "const": "associatedJob",
+                            "title": "Job",
                             "type": "selection",
-                            "contactDependent": true
+                            "contactDependent": true,
+                            "allowCustomValue": false,
+                            "description": "Also log this call to one of the customer's open jobs."
+                        },
+                        {
+                            "const": "newJobType",
+                            "title": "Job type",
+                            "type": "selection",
+                            "contactDependent": true,
+                            "allowCustomValue": false,
+                            "description": "Used only when Job is set to \"Create new job...\"."
                         }
                     ]
                 },
                 "messageLog": {
                     "additionalFields": [
                         {
-                            "const": "associatedDeal",
-                            "title": "Deals",
+                            "const": "associatedJob",
+                            "title": "Job",
                             "type": "selection",
-                            "contactDependent": true
+                            "contactDependent": true,
+                            "allowCustomValue": false,
+                            "description": "Also log this conversation to one of the customer's open jobs."
+                        },
+                        {
+                            "const": "newJobType",
+                            "title": "Job type",
+                            "type": "selection",
+                            "contactDependent": true,
+                            "allowCustomValue": false,
+                            "description": "Used only when Job is set to \"Create new job...\"."
                         }
                     ]
                 }


### PR DESCRIPTION
1.  Adds Job and Job type dropdowns to the call and message log forms, listing the matched customer's open jobs; a picked job gets the log written to it as well as to customer notes, so dispatch and the crew both see it.
2. Adds a Default job setting naming a job type — when no job is picked (including every automatically logged call) the customer's open job of that type is reused, or a new one is opened.
3. Adds Can create a new job (off by default), letting a call raise new work; business unit, campaign, priority and appointment window come from admin-managed New job defaults.
4. Makes View call log open the job's page for job-linked logs and the customer's page otherwise, by encoding the ServiceTitan path in the log ID.
5. All job logic lives in the new src/connectors/servicetitan-core/jobs.ts; a job failure never blocks a log, which always reaches customer notes with a warning on the form.